### PR TITLE
Temporary fix on line numbers not showing up properly

### DIFF
--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -969,7 +969,7 @@ export default {
 .shiki.numbers .line::before {
     content: counter(step);
     counter-increment: step;
-    width: 1rem;
+    width: 1.1rem;
     margin-right: 1.5rem;
     display: inline-block;
     text-align: right;


### PR DESCRIPTION
The line numbers were not showing up as expected when double or triple digits were reached, the simplest method to solve this issue would be to increase the width, however this is only a fix for double digits, as triple digits would require too much spacing and would interfere with the aesthetics. I am not familiar with CSS counters and i would use a counter in javascript instead however i am not sure if this is avoided in the first place for a reason, and this is my first PR so i added a temporary fix by modifying the spacing value from 1rem to 1.1rem to fix the issue up till double digits