### PR TITLE
Consistent focus color and set focus to tab input when edit button is clicked.

### DIFF
--- a/components/ButtonBackground.vue
+++ b/components/ButtonBackground.vue
@@ -1,6 +1,6 @@
 <template>
     <button
-        class="relative w-10 h-10 rounded"
+        class="relative w-10 h-10 rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500"
         :class="[`background-${background}`, active ? 'border-2 border-ui-gray-200' : null]"
         @click="$emit('update:background', background)"
     >

--- a/components/ButtonBackground.vue
+++ b/components/ButtonBackground.vue
@@ -1,6 +1,6 @@
 <template>
     <button
-        class="relative w-10 h-10 rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500"
+        class="relative w-10 h-10 rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-ui-gray-700 focus:ring-ui-violet-500"
         :class="[`background-${background}`, active ? 'border-2 border-ui-gray-200' : null]"
         @click="$emit('update:background', background)"
     >

--- a/components/Dropdown.vue
+++ b/components/Dropdown.vue
@@ -2,7 +2,7 @@
     <TDropdown
         v-bind="$attrs"
         :classes="{
-            button: 'block px-4 py-2 text-sm font-semibold text-white rounded-lg transition duration-100 ease-in-out bg-ui-violet-500 border border-transparent shadow-sm hover:bg-ui-violet-600 focus:border-ui-violet-500 focus:ring-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50 disabled:opacity-50 disabled:cursor-not-allowed',
+            button: 'block px-4 py-2 text-sm font-semibold text-white rounded-lg transition duration-100 ease-in-out bg-ui-violet-500 border border-transparent shadow-sm hover:bg-ui-violet-600 focus:bg-ui-violet-600 focus:border-ui-violet-500 focus:ring-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50 disabled:opacity-50 disabled:cursor-not-allowed',
             wrapper: 'inline-flex flex-col',
             dropdownWrapper: 'relative z-10 bg-ui-gray-700',
             dropdown: 'origin-top-right absolute right-0 w-56 shadow bg-ui-gray-700 rounded-lg',

--- a/components/Editor.vue
+++ b/components/Editor.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="overflow-hidden">
-        <div ref="toolbar" class="flex items-center justify-between p-2 bg-ui-gray-700">
-            <div class="flex items-center gap-2 rounded-lg bg-ui-gray-800">
+        <div ref="toolbar" class="flex items-center justify-between bg-ui-gray-700">
+            <div class="flex items-center gap-2 m-2 rounded-lg bg-ui-gray-800 focus-within:ring-2 focus-within:ring-ui-violet-500">
                 <label
-                    class="hidden pl-2 text-xs font-semibold leading-none tracking-wide uppercase  text-ui-gray-500 xl:inline-block whitespace-nowrap"
+                    class="hidden pl-2 text-xs font-semibold leading-none tracking-wide uppercase text-ui-gray-500 xl:inline-block whitespace-nowrap"
                 >
                     Lang
                 </label>
@@ -17,7 +17,7 @@
             </div>
 
             <div class="flex items-stretch gap-4">
-                <div class="flex items-center gap-2 rounded-lg bg-ui-gray-800">
+                <div class="flex items-center gap-2 rounded-lg bg-ui-gray-800 focus-within:ring-2 focus-within:ring-ui-violet-500">
                     <label
                         class="hidden pl-2 text-xs font-semibold leading-none tracking-wide uppercase  text-ui-gray-500 xl:inline-block whitespace-nowrap"
                     >
@@ -31,24 +31,34 @@
                     />
                 </div>
 
-                <div class="items-center hidden overflow-hidden rounded-lg lg:flex">
-                    <ToolbarButton v-if="canRemove && canMoveUp" @click.native="$emit('up', id)">
+                <div class="items-center hidden rounded-lg lg:flex bg-ui-gray-800" :class="{ 'mr-2': !canToggleLayout }">
+                    <ToolbarButton 
+                        v-if="canRemove && canMoveUp" 
+                        class="rounded-l-lg mr-0.5"
+                        @click.native="$emit('up', id)">
                         <ArrowUpIcon
                             class="w-5 h-5"
                             :class="{ 'transform -rotate-90': !landscape }"
                         />
                     </ToolbarButton>
 
-                    <ToolbarButton v-if="canRemove" @click.native="$emit('remove', id)">
+                    <ToolbarButton 
+                        v-if="canRemove"
+                        :class="{ 'rounded-l-lg': !canMoveUp }"
+                        class="mr-0.5"
+                        @click.native="$emit('remove', id)">
                         <MinusIcon class="w-5 h-5" />
                     </ToolbarButton>
 
-                    <ToolbarButton type="button" @click.native="$emit('add')">
+                    <ToolbarButton 
+                        :class="{ 'mr-0.5': canMoveDown, 'rounded-r-lg': !canMoveDown, 'rounded-l-lg': !canRemove && !canMoveUp }"
+                        @click.native="$emit('add')">
                         <PlusIcon class="w-5 h-5" />
                     </ToolbarButton>
 
                     <ToolbarButton
                         v-if="canRemove && canMoveDown"
+                        class="rounded-r-lg"
                         @click.native="$emit('down', id)"
                     >
                         <ArrowDownIcon
@@ -60,11 +70,11 @@
 
                 <div
                     v-if="canToggleLayout"
-                    class="items-center hidden overflow-hidden rounded-lg lg:flex"
+                    class="mr-2 items-center hidden lg:flex"
                 >
                     <ToolbarButton
                         v-if="landscape"
-                        type="button"
+                        class="rounded-lg"
                         @click.native="$emit('update:layout', true)"
                     >
                         <CreditCardIcon class="w-5 h-5" />
@@ -72,7 +82,7 @@
 
                     <ToolbarButton
                         v-else
-                        type="button"
+                        class="rounded-lg"
                         @click.native="$emit('update:layout', false)"
                     >
                         <ColumnsIcon class="w-5 h-5" />

--- a/components/FileDropdown.vue
+++ b/components/FileDropdown.vue
@@ -2,7 +2,7 @@
     <TDropdown
         v-bind="$attrs"
         :classes="{
-            button: 'block px-4 py-2 text-sm font-semibold text-white rounded-r-lg transition duration-100 ease-in-out bg-ui-violet-500 border border-transparent shadow-sm hover:bg-ui-violet-600 focus:border-ui-violet-500 focus:ring-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50 disabled:opacity-50 disabled:cursor-not-allowed',
+            button: 'block px-4 py-2 text-sm font-semibold text-white rounded-r-lg transition duration-100 ease-in-out bg-ui-violet-500 border border-transparent shadow-sm hover:bg-ui-violet-600 focus:border-ui-violet-500 focus:ring-2 focus:bg-ui-violet-600 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50 disabled:opacity-50 disabled:cursor-not-allowed',
             wrapper: 'inline-flex flex-col',
             dropdownWrapper: 'relative z-10 bg-ui-gray-700',
             dropdown:

--- a/components/Preview.vue
+++ b/components/Preview.vue
@@ -7,7 +7,7 @@
                 <button
                     type="button"
                     @click="copyToClipboard"
-                    class="inline-flex items-center h-full gap-2 px-4 py-2 rounded-lg cursor-pointer  text-ui-gray-400 bg-ui-gray-800 hover:bg-ui-gray-900"
+                    class="inline-flex items-center h-full gap-2 px-4 py-2 rounded-lg cursor-pointer text-ui-gray-400 bg-ui-gray-800 hover:bg-ui-gray-900 focus:bg-ui-gray-900 focus:outline-none focus:ring-2 focus:ring-ui-violet-500"
                 >
                     <CheckIcon v-if="copied" class="text-green-300" />
                     <ClipboardIcon v-else class="w-4 h-4" />
@@ -25,7 +25,7 @@
                         <button
                             type="button"
                             @click="() => $nuxt.$emit('clear-focused')"
-                            class="inline-flex items-center h-full gap-2 px-2 py-1 text-sm rounded-lg cursor-pointer  text-ui-gray-400 bg-ui-gray-800 hover:bg-ui-gray-900"
+                            class="inline-flex items-center h-full gap-2 px-2 py-1 text-sm rounded-lg cursor-pointer text-ui-gray-400 bg-ui-gray-800 hover:bg-ui-gray-900 focus:bg-ui-gray-900 focus:outline-none focus:ring-2 focus:ring-ui-violet-500"
                         >
                             <EyeOffIcon class="w-3 h-3" />
                             Clear Focused
@@ -34,7 +34,7 @@
                         <button
                             type="button"
                             @click="resetWindowSize"
-                            class="inline-flex items-center h-full gap-2 px-2 py-1 text-sm rounded-lg cursor-pointer  text-ui-gray-400 bg-ui-gray-800 hover:bg-ui-gray-900"
+                            class="inline-flex items-center h-full gap-2 px-2 py-1 text-sm rounded-lg cursor-pointer text-ui-gray-400 bg-ui-gray-800 hover:bg-ui-gray-900 focus:bg-ui-gray-900 focus:outline-none focus:ring-2 focus:ring-ui-violet-500"
                         >
                             <RefreshCwIcon class="w-3 h-3" />
                             Reset window size
@@ -57,25 +57,25 @@
                             <ButtonResize
                                 data-hide
                                 v-dragged="resizeFromTop"
-                                class="absolute top-0 z-10 -mt-1 left-1/2 cursor-resize-height"
+                                class="absolute top-0 z-10 -mt-1 left-1/2 cursor-resize-height rounded-full hover:bg-ui-gray-900 focus:bg-ui-gray-900 focus:outline-none focus:ring-2 focus:ring-ui-violet-500"
                             />
 
                             <ButtonResize
                                 data-hide
                                 v-dragged="resizeFromBottom"
-                                class="absolute bottom-0 z-10 -mb-1 left-1/2 cursor-resize-height"
+                                class="absolute bottom-0 z-10 -mb-1 left-1/2 cursor-resize-height rounded-full hover:bg-ui-gray-900 focus:bg-ui-gray-900 focus:outline-none focus:ring-2 focus:ring-ui-violet-500"
                             />
 
                             <ButtonResize
                                 data-hide
                                 v-dragged="resizeFromLeft"
-                                class="absolute left-0 z-10 -ml-1 top-1/2 cursor-resize-width"
+                                class="absolute left-0 z-10 -ml-1 top-1/2 cursor-resize-width rounded-full hover:bg-ui-gray-900 focus:bg-ui-gray-900 focus:outline-none focus:ring-2 focus:ring-ui-violet-500"
                             />
 
                             <ButtonResize
                                 data-hide
                                 v-dragged="resizeFromRight"
-                                class="absolute right-0 z-10 -mr-1 top-1/2 cursor-resize-width"
+                                class="absolute right-0 z-10 -mr-1 top-1/2 cursor-resize-width rounded-full hover:bg-ui-gray-900 focus:bg-ui-gray-900 focus:outline-none focus:ring-2 focus:ring-ui-violet-500"
                             />
                         </div>
 
@@ -137,6 +137,7 @@
 
                                     <Select
                                         v-model="settings.themeName"
+                                        class="focus:bg-ui-gray-900 focus:ring-2 focus:ring-ui-violet-500"
                                         :disabled="loading"
                                         :options="$shiki.themes()"
                                     />
@@ -145,13 +146,13 @@
                                 <div class="flex flex-col">
                                     <Label> Font Size </Label>
 
-                                    <Select v-model="settings.fontSize" :options="fontSizes" />
+                                    <Select v-model="settings.fontSize" :options="fontSizes" class="focus:bg-ui-gray-900 focus:ring-2 focus:ring-ui-violet-500" />
                                 </div>
 
                                 <div class="flex flex-col">
                                     <Label> Line Height </Label>
 
-                                    <Select v-model="settings.lineHeight" :options="lineHeights" />
+                                    <Select v-model="settings.lineHeight" :options="lineHeights" class="focus:bg-ui-gray-900 focus:ring-2 focus:ring-ui-violet-500" />
                                 </div>
                             </div>
 
@@ -252,13 +253,13 @@
             <a
                 target="_blank"
                 href="https://github.com/stevebauman/showcode"
-                class="transform -rotate-90 github-corner"
+                class="transform -rotate-90 github-corner group focus:outline-none"
                 aria-label="View source on GitHub"
                 ><svg
                     width="80"
                     height="80"
                     viewBox="0 0 250 250"
-                    class="text-ui-violet-900"
+                    class="text-ui-violet-900 group-focus:text-ui-violet-500 group-hover:text-ui-violet-500"
                     fill="currentColor"
                     style="transform: scale(-1, 1)"
                     aria-hidden="true"
@@ -751,7 +752,7 @@ export default {
 </script>
 
 <style lang="postcss">
-.github-corner:hover .octo-arm {
+.github-corner:hover .octo-arm, .github-corner:focus .octo-arm {
     animation: octocat-wave 560ms ease-in-out;
 }
 @keyframes octocat-wave {

--- a/components/Range.vue
+++ b/components/Range.vue
@@ -3,7 +3,7 @@
         :value="value"
         @input="$emit('input', $event.target.value)"
         type="range"
-        class="px-0.5 transition-all bg-ui-gray-800 w-full appearance-none hover:bg-ui-violet-500 rounded-xl focus:bg-ui-violet-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500"
+        class="px-0.5 transition-all bg-ui-gray-800 w-full appearance-none hover:bg-ui-violet-500 rounded-xl focus:bg-ui-violet-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-ui-gray-700 focus:ring-ui-violet-500"
     />
 </template>
 

--- a/components/Range.vue
+++ b/components/Range.vue
@@ -3,7 +3,7 @@
         :value="value"
         @input="$emit('input', $event.target.value)"
         type="range"
-        class="px-0.5 transition-all bg-ui-gray-800 w-full appearance-none hover:bg-ui-violet-500 rounded-xl"
+        class="px-0.5 transition-all bg-ui-gray-800 w-full appearance-none hover:bg-ui-violet-500 rounded-xl focus:bg-ui-violet-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500"
     />
 </template>
 

--- a/components/Select.vue
+++ b/components/Select.vue
@@ -2,7 +2,7 @@
     <select
         :value="value"
         @change="$emit('input', $event.target.value)"
-        class="text-xs font-medium text-ui-gray-400 bg-ui-gray-800 border-0 rounded-lg cursor-pointer hover:bg-ui-gray-900"
+        class="text-xs font-medium text-ui-gray-400 bg-ui-gray-800 border-0 rounded-lg cursor-pointer hover:bg-ui-gray-900 focus:bg-ui-gray-900 focus:outline-none focus:ring-0"
     >
         <option v-for="option in selectable" :value="option.name" :key="option.name">
             {{ option.title }}

--- a/components/Tab.vue
+++ b/components/Tab.vue
@@ -19,6 +19,7 @@
         <button
             @click="$emit('navigate')"
             @focus="focusing = true"
+            @blur="focusing = false"
             :class="{ 'font-semibold tracking-wide': active }"
             class="flex items-center w-40 h-full px-6 py-1 space-x-4 focus:outline-none"
         >
@@ -37,6 +38,7 @@
         <button
             @click="toggleEditing"
             @focus="focusing = true"
+            @blur="focusing = false"
             class="
                 inline-flex
                 items-center
@@ -61,6 +63,7 @@
         <button
             @click="$emit('close')"
             @focus="focusing = true"
+            @blur="focusing = false"
             class="
                 inline-flex
                 items-center

--- a/components/Tab.vue
+++ b/components/Tab.vue
@@ -18,12 +18,14 @@
 
         <button
             @click="$emit('navigate')"
+            @focus="focusing = true"
             :class="{ 'font-semibold tracking-wide': active }"
             class="flex items-center w-40 h-full px-6 py-1 space-x-4"
         >
             <input
                 v-if="editingName"
                 v-model="localName"
+                ref="tabName"
                 type="text"
                 @keyup.enter="save"
                 class="w-full p-0 text-xs font-semibold tracking-wide truncate bg-transparent border-0 shadow-none  focus:ring-0"
@@ -34,6 +36,7 @@
 
         <button
             @click="toggleEditing"
+            @focus="focusing = true"
             class="
                 inline-flex
                 items-center
@@ -47,7 +50,7 @@
                 hover:bg-ui-gray-900 hover:text-ui-gray-100
             "
         >
-            <span v-if="hovering || editingName">
+            <span v-if="hovering || focusing || editingName">
                 <CheckIcon v-if="editingName" />
                 <Edit3Icon class="w-5 h-5" v-else />
             </span>
@@ -55,6 +58,7 @@
 
         <button
             @click="$emit('close')"
+            @focus="focusing = true"
             class="
                 inline-flex
                 items-center
@@ -88,6 +92,7 @@ export default {
         return {
             localName: this.name,
             hovering: false,
+            focusing: false,
             editingName: false,
         };
     },
@@ -95,8 +100,12 @@ export default {
     methods: {
         toggleEditing() {
             this.$emit('navigate');
-
-            this.editingName ? this.save() : (this.editingName = true);
+            if (this.editingName) {
+                this.save();
+            } else {
+                this.editingName = true;
+                this.$nextTick(() => this.$refs.tabName.focus());
+            }
         },
 
         save() {

--- a/components/Tab.vue
+++ b/components/Tab.vue
@@ -2,7 +2,7 @@
     <div
         @mouseenter="hovering = true"
         @mouseleave="hovering = false"
-        class="relative flex items-center h-full rounded-lg hover:bg-ui-gray-900"
+        class="relative flex items-center h-full py-2 rounded-lg hover:bg-ui-gray-900 group focus-within:ring-2 focus-within:ring-ui-violet-500 focus-within:bg-ui-gray-900"
         :class="{
             'text-ui-gray-50 bg-ui-gray-600': active,
             'text-ui-gray-400 bg-ui-gray-700': !active,
@@ -20,7 +20,7 @@
             @click="$emit('navigate')"
             @focus="focusing = true"
             :class="{ 'font-semibold tracking-wide': active }"
-            class="flex items-center w-40 h-full px-6 py-1 space-x-4"
+            class="flex items-center w-40 h-full px-6 py-1 space-x-4 focus:outline-none"
         >
             <input
                 v-if="editingName"
@@ -28,7 +28,7 @@
                 ref="tabName"
                 type="text"
                 @keyup.enter="save"
-                class="w-full p-0 text-xs font-semibold tracking-wide truncate bg-transparent border-0 shadow-none  focus:ring-0"
+                class="w-full p-0 text-xs font-semibold tracking-wide truncate bg-transparent border-0 shadow-none focus:ring-0"
             />
 
             <span v-else class="text-xs truncate">{{ name }}</span>
@@ -48,6 +48,8 @@
                 text-ui-gray-400
                 rounded-lg
                 hover:bg-ui-gray-900 hover:text-ui-gray-100
+                focus:outline-none focus:text-ui-gray-100 focus:bg-ui-gray-900
+                focus:ring-2 focus:ring-ui-violet-500
             "
         >
             <span v-if="hovering || focusing || editingName">
@@ -66,10 +68,12 @@
                 w-6
                 h-6
                 p-0.5
-                mx-1
+                mr-2
                 text-ui-gray-400
                 rounded-lg
                 hover:bg-ui-gray-900 hover:text-ui-gray-100
+                focus:outline-none focus:text-ui-gray-100 focus:bg-ui-gray-900
+                focus:ring-2 focus:ring-ui-violet-500
             "
         >
             <XIcon />

--- a/components/Toggle.vue
+++ b/components/Toggle.vue
@@ -4,13 +4,13 @@
         v-model="localValue"
         :classes="{
             wrapper:
-                'bg-ui-gray-800 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
+                'bg-ui-gray-800 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-offset-ui-gray-700 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
             wrapperChecked:
-                'bg-ui-violet-500 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
+                'bg-ui-violet-500 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-offset-ui-gray-700 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
             wrapperDisabled:
-                'bg-ui-gray-100 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
+                'bg-ui-gray-100 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-offset-ui-gray-700 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
             wrapperCheckedDisabled:
-                'bg-ui-violet-500 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
+                'bg-ui-violet-500 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-offset-ui-gray-700 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
             button: 'h-4 w-4 rounded-full bg-white shadow flex items-center justify-center text-ui-gray-400 text-xs',
             buttonChecked:
                 'h-4 w-4 rounded-full bg-white shadow flex items-center justify-center text-ui-violet-500 text-xs',

--- a/components/Toggle.vue
+++ b/components/Toggle.vue
@@ -4,13 +4,13 @@
         v-model="localValue"
         :classes="{
             wrapper:
-                'bg-ui-gray-800 rounded-full border-2 border-transparent focus:ring-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
+                'bg-ui-gray-800 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
             wrapperChecked:
-                'bg-ui-violet-500 rounded-full border-2 border-transparent focus:ring-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
+                'bg-ui-violet-500 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
             wrapperDisabled:
-                'bg-ui-gray-100 rounded-full border-2 border-transparent focus:ring-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
+                'bg-ui-gray-100 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
             wrapperCheckedDisabled:
-                'bg-ui-violet-500 rounded-full border-2 border-transparent focus:ring-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
+                'bg-ui-violet-500 rounded-full border-2 border-transparent focus:ring-2 focus:ring-offset-2 focus:ring-ui-violet-500 focus:outline-none focus:ring-opacity-50',
             button: 'h-4 w-4 rounded-full bg-white shadow flex items-center justify-center text-ui-gray-400 text-xs',
             buttonChecked:
                 'h-4 w-4 rounded-full bg-white shadow flex items-center justify-center text-ui-violet-500 text-xs',

--- a/components/ToolbarButton.vue
+++ b/components/ToolbarButton.vue
@@ -1,7 +1,7 @@
 <template>
     <button
         type="button"
-        class="py-0.5 px-2 h-full"
+        class="py-0.5 px-2 h-full outline-none ring-0 focus:bg-ui-gray-900 focus-visible:outline-none focus-visible:ring-0 focus:ring-2 focus:ring-ui-violet-500"
         :class="{
             'bg-ui-gray-800 text-ui-gray-300 hover:bg-ui-gray-900': !$attrs.disabled,
             'bg-ui-gray-600 cursor-not-allowed text-ui-gray-400': $attrs.disabled,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,12 +1,12 @@
 <template>
     <div
-        class="flex flex-col h-full overflow-hidden antialiased  bg-gradient-to-bl from-ui-gray-900 via-ui-gray-800 to-ui-gray-700"
+        class="flex flex-col h-full overflow-hidden antialiased bg-gradient-to-bl from-ui-gray-900 via-ui-gray-800 to-ui-gray-700"
     >
-        <div class="items-center justify-between hidden w-full gap-2 my-2 lg:flex">
-            <div class="flex items-center justify-between w-full h-full gap-2">
+        <div class="items-center justify-between hidden w-full lg:flex">
+            <div class="flex items-center justify-between w-full h-full">
                 <FileDropdown text="File" :options="fileOptions" />
 
-                <div class="flex w-full h-full gap-2 overflow-auto">
+                <div class="flex w-full h-full gap-2 py-2 pl-2 overflow-auto">
                     <Tab
                         v-for="tab in sortedTabs"
                         :key="tab.id"
@@ -19,13 +19,13 @@
 
                     <button
                         @click="() => addTab()"
-                        class="flex items-center h-full px-4 py-1 space-x-4 rounded-lg  text-ui-gray-400 bg-ui-gray-700 hover:text-ui-gray-300 hover:bg-ui-gray-900"
+                        class="flex items-center h-full px-4 py-1 space-x-4 rounded-lg text-ui-gray-400 bg-ui-gray-700 hover:text-ui-gray-300 hover:bg-ui-gray-900                 focus:outline-none focus:text-ui-gray-100 focus:bg-ui-gray-900 focus:ring-2 focus:ring-ui-violet-500"
                     >
                         <PlusIcon class="w-6 h-6" />
                     </button>
                 </div>
 
-                <ToggleDarkMode class="mx-4 text-ui-violet-500">
+                <ToggleDarkMode class="mx-2 p-2 text-ui-violet-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-ui-violet-500">
                     <template #default="{ dark }">
                         <MoonIcon v-if="dark" size="1.5x" />
                         <SunIcon v-else size="1.5x" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,4 +38,9 @@ module.exports = {
         }
       },
     },
+    variants: {
+      extend: {
+        textColor: ['group-focus'],
+      },
+    },
 }


### PR DESCRIPTION
Clicking the edit button on a tab will now automatically focus the input element. I've also begun the process of making the focus styling more consistent. Maybe the close and edit buttons don't need `focus:ring-2 focus:ring-ui-violet-500`? 