### PR TITLE
Use the ClipboardItem API if available on Firefox

### DIFF
--- a/components/Preview.vue
+++ b/components/Preview.vue
@@ -745,7 +745,7 @@ export default {
                 case 'safari':
                     return copy(promise);
                 case 'firefox':
-                    return this.$nuxt.$emit(
+                    return typeof ClipboardItem !== 'undefined' ? promise.then(copy) : this.$nuxt.$emit(
                         'alert',
                         'danger',
                         'In order to copy images to the clipboard, Showcode.app needs access to the ClipboardItem web API, which is not accessible in Firefox. Please use the "Export" button instead.'


### PR DESCRIPTION
In response to #73, #84 disabled the copy button for Firefox users altogether.

However, as stated in the issue, it is possible to set `dom.events.asyncClipboard.clipboardItem` to `true` in `about:config`, which effectively activates the ClipboardItem API.

This PR will check if the ClipboardItem is available and use it, only displaying the alert if it is disabled.

I just tried using the Copy button that was working great for me and was a bit disappointed to see it completely disabled 😉 