### PR TITLE
fix: get system prefers-color-scheme

### DIFF
--- a/components/ToggleDarkMode.vue
+++ b/components/ToggleDarkMode.vue
@@ -15,7 +15,7 @@ export default {
     async mounted() {
         if (await this.hasInStorage()) {
             this.toggleDarkMode(await this.getFromStorage());
-        } else if (process.isClient && window.matchMedia) {
+        } else if (process.browser && window.matchMedia) {
             this.toggleDarkMode(this.detectPrefered());
         }
     },

--- a/components/ToggleDarkMode.vue
+++ b/components/ToggleDarkMode.vue
@@ -15,7 +15,7 @@ export default {
     async mounted() {
         if (await this.hasInStorage()) {
             this.toggleDarkMode(await this.getFromStorage());
-        } else if (process.browser && window.matchMedia) {
+        } else if (process.client && window.matchMedia) {
             this.toggleDarkMode(this.detectPrefered());
         }
     },


### PR DESCRIPTION
I use Mac (OSx) and Chrome with default Dark mode and, the theme always is Light.