### PR TITLE
Updated error message to use button's new label

### DIFF
--- a/components/Preview.vue
+++ b/components/Preview.vue
@@ -539,7 +539,7 @@ export default {
                         : $bus.$emit(
                               'alert',
                               'danger',
-                              'In order to copy images to the clipboard, Showcode.app needs access to the ClipboardItem web API, which is not accessible in Firefox. Please use the "Export" button instead.'
+                              'In order to copy images to the clipboard, Showcode.app needs access to the ClipboardItem web API, which is not accessible in Firefox. Please use the "Download" button instead.'
                           );
                 default:
                     return promise.then(copy);


### PR DESCRIPTION
Hey @stevebauman! I was just using Showcode (in Firefox) to build up a code snippet for a tweet today.

I think I might have spotted a mistake in the error pop up when trying to press the "Copy" button. The error message says:

> In order to copy images to the clipboard, Showcode.app needs access to the ClipboardItem web API, which is not accessible in Firefox. Please use the "Export" button instead.

I might be completely wrong on this one (apologies if so), but I couldn't see an "Export" button. It looks like the "Export" button was relabeled to "Download" a few days ago in this commit: https://github.com/stevebauman/showcode/commit/e2f4cd191dd6e6d94406353007859510d7fcc47c

So, I've updated the message to say:

> In order to copy images to the clipboard, Showcode.app needs access to the ClipboardItem web API, which is not accessible in Firefox. Please use the "Download" button instead.

Hopefully, I've done this is in the right place. But if I haven't (or if this PR isn't needed), feel free to close it 😄