### PR TITLE
Add ability to use a comment annotation to highlight lines with a specific color

### DIFF
--- a/components/Code.vue
+++ b/components/Code.vue
@@ -1,74 +1,21 @@
 <template>
-    <div class="shiki" :class="{ focus: focusing }">
-        <span
+    <div :class="{ focus: focusing }">
+        <CodeLine
+            class="whitespace-pre line"
             v-for="(line, lineIndex) in lines"
             :key="`line-${lineIndex}`"
-            :style="{
-                paddingLeft: `${padding}px`,
-                paddingRight: `${padding}px`,
-                backgroundColor: lineIsBeingRemoved(line)
-                    ? diffRemoveBgColor
-                    : lineIsBeingAdded(line)
-                    ? diffAddBgColor
-                    : 'inherit',
-            }"
-            class="relative block w-full line"
-            :class="{ focus: lineIsBeingFocused(line) }"
-            ><span
-                v-if="showLineNumbers"
-                class="number"
-                :style="{
-                    color: lineIsBeingRemoved(line)
-                        ? diffRemoveTextColor
-                        : lineIsBeingAdded(line)
-                        ? diffAddTextColor
-                        : null,
-                }"
-                >{{
-                    lineIsBeingAdded(line) ? '+' : lineIsBeingRemoved(line) ? '-' : lineIndex + 1
-                }}</span
-            ><span v-if="line.length === 0">&#10;</span
-            ><span
-                v-for="(token, tokenIndex) in line"
-                v-show="!tokenContainsAnnotation(token)"
-                :key="`token-${tokenIndex}`"
-                :style="{
-                    color: token.color,
-                    ...tokenFontStyle(token),
-                }"
-                v-html="escapeHtml(token.content)"
-            ></span
-        ></span>
+            :line="line"
+            :padding="padding"
+            :number="lineIndex"
+            :show-line-numbers="showLineNumbers"
+        />
     </div>
 </template>
 
 <script>
-import chroma from 'chroma-js';
-import collect from 'collect.js';
-import { some, includes } from 'lodash';
+import { some } from 'lodash';
 import { computed, toRefs } from '@nuxtjs/composition-api';
-
-const FONT_STYLE = {
-    NotSet: -1,
-    None: 0,
-    Italic: 1,
-    Bold: 2,
-    Underline: 4,
-};
-
-const FONT_STYLE_TO_CSS = {
-    [FONT_STYLE.Bold]: { fontWeight: 'bold' },
-    [FONT_STYLE.Italic]: { fontStyle: 'italic' },
-    [FONT_STYLE.Underline]: { textDecoration: 'underline' },
-};
-
-const htmlEscapes = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;',
-};
+import useCodeUtilities from '../composables/useCodeUtilities';
 
 export default {
     props: {
@@ -95,84 +42,30 @@ export default {
     },
 
     setup(props) {
-        const { lines, themeType } = toRefs(props);
+        const { lines } = toRefs(props);
 
-        const escapeHtml = (html) => html.replace(/[&<>"']/g, (chr) => htmlEscapes[chr]);
+        const { tokensContainFocus } = useCodeUtilities();
 
-        const lineContainsValue = (line, value) =>
-            collect(line).contains(({ content }) => content.includes(value));
-
-        const lineIsBeingAdded = (line) => lineContainsValue(line, '{+}');
-        const lineIsBeingRemoved = (line) => lineContainsValue(line, '{-}');
-        const lineIsBeingFocused = (line) => lineContainsValue(line, '{*}');
+        const lineIsBeingFocused = (line) => tokensContainFocus(line);
 
         const focusing = computed(() => some(lines.value, (line) => lineIsBeingFocused(line)));
 
-        const tokenContainsAnnotation = (token) =>
-            some(['{-}', '{+}', '{*}'], (annotation) => includes(token.content, annotation));
-
-        const diffAddRgb = [22, 250, 74];
-        const diffRemoveRgb = [250, 38, 38];
-
-        const diffAddBgColor = computed(() =>
-            chroma(diffAddRgb).alpha(themeType.value === 'light' ? 0.2 : 0.3)
-        );
-
-        const diffRemoveBgColor = computed(() =>
-            chroma(diffRemoveRgb).alpha(themeType.value === 'light' ? 0.2 : 0.3)
-        );
-
-        const diffAddTextColor = computed(() =>
-            chroma(diffAddRgb).darken(themeType.value === 'light' ? 1 : -3)
-        );
-
-        const diffRemoveTextColor = computed(() =>
-            chroma(diffRemoveRgb).darken(themeType.value === 'light' ? 1 : -3)
-        );
-
-        const tokenFontStyle = (token) =>
-            token.fontStyle > FONT_STYLE.None ? FONT_STYLE_TO_CSS[token.fontStyle] : {};
-
         return {
             focusing,
-            escapeHtml,
-            tokenFontStyle,
-            tokenContainsAnnotation,
-            lineIsBeingAdded,
-            lineIsBeingRemoved,
             lineIsBeingFocused,
-            diffAddBgColor,
-            diffRemoveBgColor,
-            diffAddTextColor,
-            diffRemoveTextColor,
         };
     },
 };
 </script>
 
-<style lang="postcss">
-.shiki .line {
-    white-space: pre;
-    word-break: normal;
-    word-wrap: break-word;
-}
-
-.shiki.focus .line:not(.focus) {
+<style scoped lang="postcss">
+.focus .line:not(.focus) {
     filter: blur(1px);
     transition: filter 250ms;
 }
 
-.shiki.focus:hover .line {
+.focus .focus:hover .line {
     filter: blur(0);
     transition: filter 250ms;
-}
-
-.shiki .line .number {
-    width: 1rem;
-    white-space: pre;
-    margin-right: 1rem;
-    display: inline-block;
-    text-align: right;
-    color: rgba(115, 138, 148, 0.5);
 }
 </style>

--- a/components/CodeLine.vue
+++ b/components/CodeLine.vue
@@ -1,0 +1,152 @@
+<template>
+    <span
+        :style="{
+            paddingLeft: `${padding}px`,
+            paddingRight: `${padding}px`,
+            backgroundColor: `${backgroundColor}`,
+        }"
+        class="relative block w-full"
+        :class="{ focus: lineIsBeingFocused }"
+        ><span v-if="showLineNumbers" class="w-4 mr-4 text-right" :style="{ color: color }">{{
+            lineIsBeingAdded ? '+' : lineIsBeingRemoved ? '-' : number + 1
+        }}</span
+        ><span v-if="line.length === 0">&#10;</span
+        ><span
+            v-for="(token, tokenIndex) in line"
+            v-show="!tokenContainsAnnotation(token)"
+            :key="`token-${tokenIndex}`"
+            :style="{
+                color: token.color,
+                ...tokenFontStyle(token),
+            }"
+            v-html="escapeHtml(token.content)"
+        ></span
+    ></span>
+</template>
+
+<script>
+import chroma from 'chroma-js';
+import { computed, toRefs } from '@nuxtjs/composition-api';
+import useCodeUtilities from '../composables/useCodeUtilities';
+
+export default {
+    props: {
+        line: {
+            type: Array,
+            default: () => [],
+        },
+        number: {
+            type: Number,
+            default: 0,
+        },
+        padding: {
+            type: [Number, String],
+            default: 0,
+        },
+        number: {
+            type: Number,
+            default: 0,
+        },
+        showLineNumbers: {
+            type: Boolean,
+            default: false,
+        },
+        themeType: {
+            type: String,
+            default: 'light',
+        },
+    },
+
+    setup(props) {
+        const { line, themeType } = toRefs(props);
+
+        const {
+            escapeHtml,
+            findHexInTokens,
+            tokenFontStyle,
+            tokensContainHex,
+            tokensContainAdd,
+            tokensContainFocus,
+            tokensContainRemove,
+            tokenContainsAnnotation,
+        } = useCodeUtilities();
+
+        const lineIsBeingAdded = computed(() => tokensContainAdd(line.value));
+        const lineIsBeingRemoved = computed(() => tokensContainRemove(line.value));
+        const lineIsBeingFocused = computed(() => tokensContainFocus(line.value));
+        const lineIsBeingHighlighted = computed(() => tokensContainHex(line.value));
+
+        const color = computed(() => {
+            switch (true) {
+                case lineIsBeingAdded.value:
+                    return diffAddTextColor.value;
+                case lineIsBeingRemoved.value:
+                    return diffRemoveTextColor.value;
+                default:
+                    return null;
+            }
+        });
+
+        const backgroundColor = computed(() => {
+            switch (true) {
+                case lineIsBeingAdded.value:
+                    return diffAddBgColor.value;
+                case lineIsBeingRemoved.value:
+                    return diffRemoveBgColor.value;
+                case lineIsBeingHighlighted.value:
+                    return highlightBgColor.value;
+                default:
+                    return 'inherit';
+            }
+        });
+
+        const diffAddRgb = [22, 250, 74];
+        const diffRemoveRgb = [250, 38, 38];
+
+        const diffAddBgColor = computed(() =>
+            chroma(diffAddRgb)
+                .alpha(themeType.value === 'light' ? 0.2 : 0.3)
+                .css()
+        );
+
+        const diffRemoveBgColor = computed(() =>
+            chroma(diffRemoveRgb)
+                .alpha(themeType.value === 'light' ? 0.2 : 0.3)
+                .css()
+        );
+
+        const diffAddTextColor = computed(() =>
+            chroma(diffAddRgb)
+                .darken(themeType.value === 'light' ? 1 : -3)
+                .css()
+        );
+
+        const diffRemoveTextColor = computed(() =>
+            chroma(diffRemoveRgb)
+                .darken(themeType.value === 'light' ? 1 : -3)
+                .css()
+        );
+
+        const highlightBgColor = computed(() => {
+            const color = findHexInTokens(line.value);
+
+            try {
+                return chroma(color).css();
+            } catch (e) {
+                return null;
+            }
+        });
+
+        return {
+            color,
+            backgroundColor,
+            escapeHtml,
+            tokenFontStyle,
+            tokenContainsAnnotation,
+            lineIsBeingAdded,
+            lineIsBeingRemoved,
+            lineIsBeingFocused,
+        };
+    },
+};
+</script>

--- a/components/Editor.vue
+++ b/components/Editor.vue
@@ -5,7 +5,7 @@
             class="flex items-center justify-between w-full overflow-auto bg-ui-gray-700 scrollbar-hide"
         >
             <div
-                class="flex items-center gap-2 m-2 rounded-lg bg-ui-gray-800 focus-within:ring-2 focus-within:ring-ui-focus"
+                class="flex items-center gap-2 m-2 rounded-lg focus-within:ring-2 focus-within:ring-ui-focus"
             >
                 <label
                     class="hidden pl-2 text-xs font-semibold leading-none tracking-wide uppercase whitespace-nowrap text-ui-gray-500 xl:inline-block"
@@ -24,7 +24,7 @@
 
             <div class="flex items-stretch gap-2">
                 <div
-                    class="flex items-center gap-2 mr-2 rounded-lg bg-ui-gray-800 focus-within:ring-2 focus-within:ring-ui-focus lg:mr-0"
+                    class="flex items-center gap-2 mr-2 rounded-lg focus-within:ring-2 focus-within:ring-ui-focus lg:mr-0"
                 >
                     <label
                         class="hidden pl-2 text-xs font-semibold leading-none tracking-wide uppercase whitespace-nowrap text-ui-gray-500 xl:inline-block"
@@ -41,7 +41,7 @@
                 </div>
 
                 <div
-                    class="items-center hidden rounded-lg bg-ui-gray-800 lg:flex"
+                    class="items-center hidden rounded-lg lg:flex"
                     :class="{ 'mr-2': !canToggleLayout }"
                 >
                     <ToolbarButton

--- a/components/ToolbarButton.vue
+++ b/components/ToolbarButton.vue
@@ -3,7 +3,7 @@
         type="button"
         class="py-0.5 px-2 h-full outline-none ring-0 focus:bg-ui-gray-900 focus-visible:outline-none focus-visible:ring-0 focus:ring-2 focus:ring-ui-focus"
         :class="{
-            'bg-ui-gray-800 text-ui-gray-300 hover:bg-ui-gray-900': !$attrs.disabled,
+            'text-ui-gray-300 hover:bg-ui-gray-900': !$attrs.disabled,
             'bg-ui-gray-600 cursor-not-allowed text-ui-gray-400': $attrs.disabled,
         }"
     >

--- a/composables/useCodeUtilities.js
+++ b/composables/useCodeUtilities.js
@@ -1,0 +1,72 @@
+import collect from 'collect.js';
+import { some, includes } from 'lodash';
+
+const FONT_STYLE = {
+    NotSet: -1,
+    None: 0,
+    Italic: 1,
+    Bold: 2,
+    Underline: 4,
+};
+
+const FONT_STYLE_TO_CSS = {
+    [FONT_STYLE.Bold]: { fontWeight: 'bold' },
+    [FONT_STYLE.Italic]: { fontStyle: 'italic' },
+    [FONT_STYLE.Underline]: { textDecoration: 'underline' },
+};
+
+const htmlEscapes = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+};
+
+const addRegex = /{\+}/;
+const removeRegex = /{\-}/;
+const focusRegex = /{\*}/;
+const hexRegex = /{#[0-9A-Fa-f]{3,6}}/;
+
+export default function () {
+    const escapeHtml = (html) => html.replace(/[&<>"']/g, (chr) => htmlEscapes[chr]);
+
+    const tokenFontStyle = (token) =>
+        token.fontStyle > FONT_STYLE.None ? FONT_STYLE_TO_CSS[token.fontStyle] : {};
+
+    const tokensContainRegex = (tokens, regex) =>
+        collect(tokens).contains(({ content }) => regex.test(content));
+
+    const tokensContainHex = (tokens) => tokensContainRegex(tokens, hexRegex);
+    const tokensContainAdd = (tokens) => tokensContainRegex(tokens, addRegex);
+    const tokensContainFocus = (tokens) => tokensContainRegex(tokens, focusRegex);
+    const tokensContainRemove = (tokens) => tokensContainRegex(tokens, removeRegex);
+
+    const tokenContainsAnnotation = (token) =>
+        some([addRegex, removeRegex, focusRegex, hexRegex], (regex) => regex.test(token.content));
+
+    const findHexInTokens = (tokens) => {
+        const token = collect(tokens)
+            .filter(({ content }) => hexRegex.test(content))
+            .first();
+
+        const hex = token.content?.match(hexRegex)[0] ?? null;
+
+        if (!hex) {
+            return;
+        }
+
+        return hex.slice(1, -1);
+    };
+
+    return {
+        escapeHtml,
+        findHexInTokens,
+        tokenFontStyle,
+        tokensContainHex,
+        tokensContainAdd,
+        tokensContainFocus,
+        tokensContainRemove,
+        tokenContainsAnnotation,
+    };
+}


### PR DESCRIPTION
This PR adds the ability to supply a hex color as a code comment to highlight the background of a specific line:

```php
public function index()
{
    return view('users.index'); // {#c3ebfd}
}
```