### PR TITLE
Add "Fit to Window Lock" feature

### DIFF
--- a/components/Canvas.vue
+++ b/components/Canvas.vue
@@ -80,7 +80,7 @@ export default {
         resizable: {
             type: Boolean,
             default: true,
-            required: true,
+            required: false,
         },
         aspectRatio: {
             type: Array,

--- a/components/Canvas.vue
+++ b/components/Canvas.vue
@@ -5,7 +5,7 @@
             width: `${width}px`,
             height: `${height}px`,
         }"
-        :resizable="resizable"
+        :resize="resize"
         @resizemove="onResize"
     >
         <div class="absolute inset-0 z-[2] w-full h-full bg-overlay pointer-events-none"></div>
@@ -20,29 +20,31 @@
         <!-- Optional grid. Left out for a future implementation. -->
         <!-- <div class="absolute z-[2] w-full h-full bg-grid pointer-events-none"></div> -->
 
-        <ButtonResize
-            ref="top"
-            data-hide
-            class="absolute top-0 left-1/2 -m-1.5 cursor-resize-height resize-top"
-        />
+        <template v-if="resizable">
+            <ButtonResize
+                ref="top"
+                data-hide
+                class="absolute top-0 left-1/2 -m-1.5 cursor-resize-height resize-top"
+            />
 
-        <ButtonResize
-            ref="bottom"
-            data-hide
-            class="absolute bottom-0 left-1/2 -m-1.5 cursor-resize-height resize-bottom"
-        />
+            <ButtonResize
+                ref="bottom"
+                data-hide
+                class="absolute bottom-0 left-1/2 -m-1.5 cursor-resize-height resize-bottom"
+            />
 
-        <ButtonResize
-            ref="left"
-            data-hide
-            class="absolute left-0 top-1/2 -m-1.5 cursor-resize-width resize-left"
-        />
+            <ButtonResize
+                ref="left"
+                data-hide
+                class="absolute left-0 top-1/2 -m-1.5 cursor-resize-width resize-left"
+            />
 
-        <ButtonResize
-            data-hide
-            ref="right"
-            class="absolute right-0 top-1/2 -m-1.5 cursor-resize-width resize-right"
-        />
+            <ButtonResize
+                data-hide
+                ref="right"
+                class="absolute right-0 top-1/2 -m-1.5 cursor-resize-width resize-right"
+            />
+        </template>
 
         <div class="relative flex items-center justify-center flex-1">
             <slot />
@@ -73,6 +75,11 @@ export default {
         },
         height: {
             type: Number,
+            required: true,
+        },
+        resizable: {
+            type: Boolean,
+            default: true,
             required: true,
         },
         aspectRatio: {
@@ -108,7 +115,7 @@ export default {
             }
         });
 
-        const resizable = computed(() => ({
+        const resize = computed(() => ({
             edges: {
                 top: top.value?.$el,
                 right: right.value?.$el,
@@ -142,7 +149,7 @@ export default {
             }
         };
 
-        return { x, y, top, right, bottom, left, resizable, onResize };
+        return { x, y, top, right, bottom, left, resize, onResize };
     },
 };
 </script>

--- a/components/Input.vue
+++ b/components/Input.vue
@@ -4,7 +4,7 @@
         :class="[sizes[size]]"
         :type="$attrs.type || 'text'"
         @input="$emit('input', $event.target.value)"
-        class="border-0 rounded-lg text-ui-gray-400 disabled:cursor-not-allowed disabled:bg-ui-gray-900 bg-ui-gray-600 hover:bg-ui-gray-900 focus:outline-none focus:bg-ui-gray-900 focus:ring-2 focus:ring-ui-focus"
+        class="border-0 rounded-lg text-ui-gray-400 disabled:cursor-not-allowed disabled:bg-ui-gray-900 bg-ui-gray-800 hover:bg-ui-gray-900 focus:outline-none focus:bg-ui-gray-900 focus:ring-2 focus:ring-ui-focus"
     />
 </template>
 
@@ -24,7 +24,7 @@ export default {
     setup() {
         const sizes = {
             xs: 'text-xs px-2.5 py-0.5',
-            sm: 'text-sm px-3 py-2 ',
+            sm: 'text-sm px-3 py-1',
             base: 'text-sm px-4 py-2',
             lg: 'text-base font-semibold px-4 py-3',
         };

--- a/components/Input.vue
+++ b/components/Input.vue
@@ -3,8 +3,8 @@
         :value="value"
         :class="[sizes[size]]"
         :type="$attrs.type || 'text'"
-        @change="$emit('input', $event.target.value)"
-        class="border-0 rounded-lg text-ui-gray-400 bg-ui-gray-600 hover:bg-ui-gray-900 focus:outline-none focus:bg-ui-gray-900 focus:ring-2 focus:ring-ui-focus"
+        @input="$emit('input', $event.target.value)"
+        class="border-0 rounded-lg text-ui-gray-400 disabled:cursor-not-allowed disabled:bg-ui-gray-900 bg-ui-gray-600 hover:bg-ui-gray-900 focus:outline-none focus:bg-ui-gray-900 focus:ring-2 focus:ring-ui-focus"
     />
 </template>
 

--- a/components/Interact.vue
+++ b/components/Interact.vue
@@ -14,16 +14,23 @@ export default {
         as: {
             type: String,
             default: 'div',
+            required: false,
         },
-        draggable: Object,
-        resizable: Object,
+        drag: {
+            type: Object,
+            required: false,
+        },
+        resize: {
+            type: Object,
+            required: false,
+        },
     },
 
     setup(props, { emit }) {
         const root = ref(null);
         const instance = ref(null);
 
-        const { draggable, resizable } = toRefs(props);
+        const { drag, resize } = toRefs(props);
 
         const element = computed(() => (root.value instanceof Vue ? root.value.$el : root.value));
 
@@ -35,8 +42,8 @@ export default {
             instance.value.on('dragmove', (event) => emit('dragmove', event));
             instance.value.on('resizemove', (event) => emit('resizemove', event));
 
-            watch(draggable, (config) => instance.value?.draggable(config), { immediate: true });
-            watch(resizable, (config) => instance.value?.resizable(config), { immediate: true });
+            watch(drag, (config) => instance.value?.draggable(config), { immediate: true });
+            watch(resize, (config) => instance.value?.resizable(config), { immediate: true });
         });
 
         onBeforeUnmount(destroy);

--- a/components/ModalPreferences.vue
+++ b/components/ModalPreferences.vue
@@ -121,25 +121,27 @@
                     </div>
                 </FormGroup>
 
-                <FormGroup v-if="preferences.previewLockToWindow">
-                    <Label>Default Padding X</Label>
+                <template v-if="preferences.previewLockToWindow">
+                    <FormGroup>
+                        <Label>Default Padding X</Label>
 
-                    <Input
-                        size="sm"
-                        dusk="input-preview-lock-to-window-padding-x"
-                        v-model="preferences.previewLockToWindowPaddingX"
-                    />
-                </FormGroup>
+                        <Input
+                            size="sm"
+                            dusk="input-preview-lock-to-window-padding-x"
+                            v-model="preferences.previewLockToWindowPaddingX"
+                        />
+                    </FormGroup>
 
-                <FormGroup v-if="preferences.previewLockToWindow">
-                    <Label>Default Padding Y</Label>
+                    <FormGroup>
+                        <Label>Default Padding Y</Label>
 
-                    <Input
-                        size="sm"
-                        dusk="input-preview-lock-to-window-padding-y"
-                        v-model="preferences.previewLockToWindowPaddingY"
-                    />
-                </FormGroup>
+                        <Input
+                            size="sm"
+                            dusk="input-preview-lock-to-window-padding-y"
+                            v-model="preferences.previewLockToWindowPaddingY"
+                        />
+                    </FormGroup>
+                </template>
 
                 <FormDivider />
 

--- a/components/ModalPreferences.vue
+++ b/components/ModalPreferences.vue
@@ -107,6 +107,43 @@
                 <FormDivider />
 
                 <FormGroup>
+                    <Label>Always Lock Fit To Window</Label>
+
+                    <div class="flex items-center">
+                        <Toggle
+                            dusk="toggle-preview-lock-to-window"
+                            v-model="preferences.previewLockToWindow"
+                        />
+
+                        <div class="ml-2 text-sm text-ui-gray-500">
+                            ({{ preferences.previewLockToWindow ? 'Yes' : 'No' }})
+                        </div>
+                    </div>
+                </FormGroup>
+
+                <FormGroup v-if="preferences.previewLockToWindow">
+                    <Label>Default Padding X</Label>
+
+                    <Input
+                        size="sm"
+                        dusk="input-preview-lock-to-window-padding-x"
+                        v-model="preferences.previewLockToWindowPaddingX"
+                    />
+                </FormGroup>
+
+                <FormGroup v-if="preferences.previewLockToWindow">
+                    <Label>Default Padding Y</Label>
+
+                    <Input
+                        size="sm"
+                        dusk="input-preview-lock-to-window-padding-y"
+                        v-model="preferences.previewLockToWindowPaddingY"
+                    />
+                </FormGroup>
+
+                <FormDivider />
+
+                <FormGroup>
                     <Label>
                         Export Pixel Ratio
                         <br />

--- a/components/ModalPreferences.vue
+++ b/components/ModalPreferences.vue
@@ -99,7 +99,7 @@
                 </FormGroup>
 
                 <FormGroup>
-                    <Label>Line Height</Label>
+                    <Label>Preview Line Height</Label>
 
                     <Select v-model="preferences.previewLineHeight" :options="lineHeights" />
                 </FormGroup>

--- a/components/Popover.vue
+++ b/components/Popover.vue
@@ -6,7 +6,6 @@
         @update:open="open = $event"
         boundaries-element="body"
         popover-inner-class="border-2 rounded-lg shadow-xl bg-ui-gray-700 border-ui-gray-800"
-        class="flex items-center w-full h-full px-1 py-1 mx-1 bg-ui-gray-800 hover:bg-ui-gray-900 rounded-xl"
     >
         <slot name="trigger" />
 

--- a/components/Preview.vue
+++ b/components/Preview.vue
@@ -65,6 +65,7 @@
                     :scale="settings.scale"
                     :width="settings.width"
                     :height="settings.height"
+                    :resizable="!lockWindowSize"
                     :aspect-ratio="settings.aspectRatio"
                     :background="settings.background"
                     :background-attributes="backgroundAttrs"
@@ -701,6 +702,10 @@ export default {
         const generateImageFromPreview = (method, pixelRatio = 3) => {
             const filter = (node) => !(node.dataset && node.dataset.hasOwnProperty('hide'));
 
+            if (!canvas.value?.$el) {
+                return;
+            }
+
             return htmlToImage[method](canvas.value.$el, {
                 filter,
                 pixelRatio,
@@ -840,6 +845,8 @@ export default {
             // so performance doesn't take a hit.
             watch(code, debounce(generateTokens, 500));
 
+            watch([languages, themeName, themeOpacity], generateTokens);
+
             watch([blocks, lockWindowSize, lockWindowPaddingX, lockWindowPaddingY], () => {
                 if (lockWindowSize.value) {
                     nextTick(() => {
@@ -848,8 +855,6 @@ export default {
                     });
                 }
             });
-
-            watch([languages, themeName, themeOpacity], generateTokens);
 
             watch(
                 () => [settings, code],

--- a/components/Preview.vue
+++ b/components/Preview.vue
@@ -73,7 +73,7 @@
                     @update:height="setHeight($event)"
                 >
                     <Window
-                        ref="window"
+                        ref="pane"
                         class="z-[1] absolute flex-shrink-0 exclude-from-panzoom"
                         :blocks="blocks"
                         :settings="settings"
@@ -631,11 +631,10 @@ export default {
     },
 
     setup(props, context) {
-        const object = ref(null);
         const preview = ref(null);
         const canvas = ref(null);
         const blocks = ref([]);
-        const window = ref(null);
+        const pane = ref(null);
         const exportAs = ref('png');
         const resizing = ref(false);
         const backgroundButtons = ref([]);
@@ -850,8 +849,8 @@ export default {
             watch([blocks, lockWindowSize, lockWindowPaddingX, lockWindowPaddingY], () => {
                 if (lockWindowSize.value) {
                     nextTick(() => {
-                        setWidth(window.value.actualWidth() + Number(lockWindowPaddingX.value));
-                        setHeight(window.value.actualHeight() + Number(lockWindowPaddingY.value));
+                        setWidth(pane.value.actualWidth() + Number(lockWindowPaddingX.value));
+                        setHeight(pane.value.actualHeight() + Number(lockWindowPaddingY.value));
                     });
                 }
             });
@@ -866,7 +865,7 @@ export default {
         onBeforeUnmount(() => templateGenerationDebounce?.cancel());
 
         return {
-            object,
+            pane,
             zoom,
             isEqual,
             canvas,
@@ -878,7 +877,6 @@ export default {
             copyToClipboard,
             blocks,
             zoomTo,
-            window,
             exportAs,
             resizing,
             setWidth,

--- a/components/Preview.vue
+++ b/components/Preview.vue
@@ -842,7 +842,6 @@ export default {
 
             watch([blocks, lockWindowSize, lockWindowPaddingX, lockWindowPaddingY], () => {
                 if (lockWindowSize.value) {
-                    console.log(lockWindowPaddingX.value);
                     nextTick(() => {
                         setWidth(window.value.actualWidth() + Number(lockWindowPaddingX.value));
                         setHeight(window.value.actualHeight() + Number(lockWindowPaddingY.value));

--- a/components/Toggle.vue
+++ b/components/Toggle.vue
@@ -28,7 +28,12 @@
             }"
         />
 
-        <Popover v-if="$slots.popover && localValue" :title="popoverTitle" @reset="$emit('reset')">
+        <Popover
+            v-if="$slots.popover && localValue"
+            :title="popoverTitle"
+            @reset="$emit('reset')"
+            class="flex items-center w-full h-full px-1 py-1 mx-1 bg-ui-gray-800 hover:bg-ui-gray-900 rounded-xl"
+        >
             <template #trigger>
                 <button type="button" class="flex items-center h-full text-ui-gray-300">
                     <SettingsIcon class="w-4 h-4" />
@@ -50,8 +55,14 @@ export default {
     inheritAttrs: false,
 
     props: {
-        value: Boolean,
-        popoverTitle: String,
+        value: {
+            type: Boolean,
+            required: true,
+        },
+        popoverTitle: {
+            type: String,
+            required: false,
+        },
     },
 
     components: { SettingsIcon },

--- a/composables/useButtonClasses.js
+++ b/composables/useButtonClasses.js
@@ -16,7 +16,7 @@ export default function (props = null) {
             active.value ? 'bg-ui-violet-600 font-bold' : null,
         ],
         secondary: [
-            'text-ui-gray-300 disabled:text-ui-gray-600 bg-ui-gray-700 hover:bg-ui-gray-900 disabled:bg-ui-gray-900 focus:bg-ui-gray-900',
+            'text-ui-gray-300 disabled:text-ui-gray-500 bg-ui-gray-700 hover:bg-ui-gray-900 disabled:bg-ui-gray-900 focus:bg-ui-gray-900',
             active.value ? 'bg-ui-gray-900 font-bold' : null,
         ],
     }));

--- a/composables/useButtonClasses.js
+++ b/composables/useButtonClasses.js
@@ -16,13 +16,13 @@ export default function (props = null) {
             active.value ? 'bg-ui-violet-600 font-bold' : null,
         ],
         secondary: [
-            'text-ui-gray-300 bg-ui-gray-700 hover:bg-ui-gray-900 focus:bg-ui-gray-900',
+            'text-ui-gray-300 disabled:text-ui-gray-600 bg-ui-gray-700 hover:bg-ui-gray-900 disabled:bg-ui-gray-900 focus:bg-ui-gray-900',
             active.value ? 'bg-ui-gray-900 font-bold' : null,
         ],
     }));
 
     const classes = [
-        'inline-flex items-center gap-2 leading-none transition duration-100 ease-in-out focus:outline-none focus:ring-2 focus:ring-ui-focus',
+        'inline-flex items-center gap-2 disabled:cursor-not-allowed leading-none transition duration-100 ease-in-out focus:outline-none focus:ring-2 focus:ring-ui-focus',
     ];
 
     return { sizes, variants, classes };

--- a/composables/usePreferencesStore.js
+++ b/composables/usePreferencesStore.js
@@ -7,14 +7,18 @@ export const defaults = {
     editorTabSize: 4,
     editorLanguage: 'php',
     editorOrientation: 'left',
-    editorInitialValue: '<?php\n\n',
     editorLightTheme: 'vs-light',
     editorDarkTheme: 'oceanic-next',
+    editorInitialValue: '<?php\n\n',
 
-    previewThemeName: 'github-light',
     previewFontSize: 16,
-    previewFontFamily: 'font-mono',
     previewLineHeight: 20,
+    previewFontFamily: 'font-mono',
+    previewThemeName: 'github-light',
+
+    previewLockToWindow: false,
+    previewLockToWindowPaddingX: 0,
+    previewLockToWindowPaddingY: 0,
 
     exportPixelRatio: 3,
 

--- a/composables/usePreview.js
+++ b/composables/usePreview.js
@@ -31,6 +31,9 @@ export default function (props, context) {
         themeName: preferences.previewThemeName,
         themeBackground: '#fff',
         aspectRatio: null,
+        lockWindowSize: false,
+        lockWindowPaddingX: 0,
+        lockWindowPaddingY: 0,
 
         fontSize: preferences.previewFontSize,
         fontFamily: preferences.previewFontFamily,

--- a/composables/usePreview.js
+++ b/composables/usePreview.js
@@ -31,9 +31,10 @@ export default function (props, context) {
         themeName: preferences.previewThemeName,
         themeBackground: '#fff',
         aspectRatio: null,
-        lockWindowSize: false,
-        lockWindowPaddingX: 0,
-        lockWindowPaddingY: 0,
+
+        lockWindowSize: preferences.previewLockToWindow,
+        lockWindowPaddingX: preferences.previewLockToWindowPaddingX,
+        lockWindowPaddingY: preferences.previewLockToWindowPaddingY,
 
         fontSize: preferences.previewFontSize,
         fontFamily: preferences.previewFontFamily,


### PR DESCRIPTION
This PR adds the ability for developers to lock the dimensions of the canvas to the window size, along with having additional padding constraints. The canvas will automatically shrink and expand depending on the size of the content when it changes.

@lupinitylabs 

![Screen Shot 2022-07-08 at 4 31 11 PM](https://user-images.githubusercontent.com/6421846/178066098-32185aee-04fa-4eec-97e6-22c15af1e7ab.png)