### PR TITLE
Add saved project workflows and desktop save states

### DIFF
--- a/app/components/ModalCloseProject.vue
+++ b/app/components/ModalCloseProject.vue
@@ -1,0 +1,33 @@
+<template>
+    <Dialog :open="Boolean(project)" @update:open="handleOpenChange">
+        <DialogContent class="max-w-md">
+            <DialogHeader>
+                <DialogTitle>Save project before closing?</DialogTitle>
+                <DialogDescription>
+                    This project has unsaved changes. Save it to reopen later, discard the changes,
+                    or keep it open.
+                </DialogDescription>
+            </DialogHeader>
+
+            <DialogFooter>
+                <Button variant="ghost" @click="$emit('cancel')">Cancel</Button>
+                <Button variant="outline" @click="$emit('discard')">Discard</Button>
+                <Button @click="$emit('save')">Save Project</Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>
+
+<script setup>
+defineProps({
+    project: { type: Object, default: null },
+});
+
+const emit = defineEmits(['cancel', 'discard', 'save']);
+
+function handleOpenChange(open) {
+    if (!open) {
+        emit('cancel');
+    }
+}
+</script>

--- a/app/components/ModalRenameProject.vue
+++ b/app/components/ModalRenameProject.vue
@@ -2,9 +2,9 @@
     <Dialog :open="Boolean(project)" @update:open="handleOpenChange">
         <DialogContent class="max-w-md">
             <DialogHeader>
-                <DialogTitle>Rename project</DialogTitle>
+                <DialogTitle>{{ title }}</DialogTitle>
                 <DialogDescription>
-                    Update the project name shown in tabs and saved projects.
+                    {{ description }}
                 </DialogDescription>
             </DialogHeader>
 
@@ -13,7 +13,7 @@
 
                 <DialogFooter>
                     <Button type="button" variant="ghost" @click="$emit('cancel')">Cancel</Button>
-                    <Button type="submit">Rename</Button>
+                    <Button type="submit">{{ action }}</Button>
                 </DialogFooter>
             </form>
         </DialogContent>
@@ -25,6 +25,12 @@ import { nextTick, ref, watch } from 'vue';
 
 const props = defineProps({
     project: { type: Object, default: null },
+    title: { type: String, default: 'Rename project' },
+    description: {
+        type: String,
+        default: 'Update the project name shown in tabs and saved projects.',
+    },
+    action: { type: String, default: 'Rename' },
 });
 
 const emit = defineEmits(['cancel', 'rename']);

--- a/app/components/ModalRenameProject.vue
+++ b/app/components/ModalRenameProject.vue
@@ -1,0 +1,59 @@
+<template>
+    <Dialog :open="Boolean(project)" @update:open="handleOpenChange">
+        <DialogContent class="max-w-md">
+            <DialogHeader>
+                <DialogTitle>Rename project</DialogTitle>
+                <DialogDescription>
+                    Update the project name shown in tabs and saved projects.
+                </DialogDescription>
+            </DialogHeader>
+
+            <form class="space-y-4" @submit.prevent="rename">
+                <Input ref="input" v-model="name" />
+
+                <DialogFooter>
+                    <Button type="button" variant="ghost" @click="$emit('cancel')">Cancel</Button>
+                    <Button type="submit">Rename</Button>
+                </DialogFooter>
+            </form>
+        </DialogContent>
+    </Dialog>
+</template>
+
+<script setup>
+import { nextTick, ref, watch } from 'vue';
+
+const props = defineProps({
+    project: { type: Object, default: null },
+});
+
+const emit = defineEmits(['cancel', 'rename']);
+
+const input = ref(null);
+const name = ref('');
+
+watch(
+    () => props.project,
+    (project) => {
+        name.value = project?.tab?.name || '';
+
+        if (project) {
+            nextTick(() => input.value?.$el?.focus?.());
+        }
+    }
+);
+
+function rename() {
+    const newName = name.value.trim();
+
+    if (newName) {
+        emit('rename', newName);
+    }
+}
+
+function handleOpenChange(open) {
+    if (!open) {
+        emit('cancel');
+    }
+}
+</script>

--- a/app/components/ModalSavedProjects.vue
+++ b/app/components/ModalSavedProjects.vue
@@ -1,0 +1,101 @@
+<template>
+    <Dialog :open="modelValue" @update:open="$emit('update:modelValue', $event)">
+        <DialogContent class="flex max-h-[80vh] max-w-4xl flex-col gap-0 p-0">
+            <DialogHeader
+                class="shrink-0 border-b border-zinc-200 px-5 pt-4 pb-3 dark:border-zinc-800"
+            >
+                <DialogTitle class="text-sm font-semibold">Saved Projects</DialogTitle>
+            </DialogHeader>
+
+            <ScrollArea class="flex-1 overflow-auto">
+                <div
+                    v-if="projects.all().length"
+                    class="grid grid-flow-row grid-cols-2 gap-3 p-5 lg:grid-cols-3 xl:grid-cols-4"
+                >
+                    <div
+                        v-for="project in projects.all()"
+                        :key="project.tab.id"
+                        class="group relative flex flex-col overflow-hidden rounded-lg border border-zinc-200 transition-all hover:border-zinc-300 dark:border-zinc-800 dark:hover:border-zinc-700"
+                    >
+                        <div
+                            class="absolute top-1.5 right-1.5 z-10 flex items-center gap-0.5 rounded-md bg-white/80 opacity-0 backdrop-blur-xs transition-opacity group-hover:opacity-100 dark:bg-zinc-900/80"
+                        >
+                            <Button
+                                size="icon-sm"
+                                variant="ghost"
+                                v-tooltip.bottom="'Rename'"
+                                @click="$emit('rename', project)"
+                            >
+                                <EditIcon class="size-3.5" />
+                            </Button>
+
+                            <Button
+                                size="icon-sm"
+                                variant="ghost"
+                                class="text-red-500 hover:text-red-600 dark:hover:text-red-400"
+                                v-tooltip.bottom="'Delete'"
+                                @click="$emit('remove', project)"
+                            >
+                                <XIcon class="size-3.5" />
+                            </Button>
+                        </div>
+
+                        <button
+                            :data-saved-project-id="project.tab.id"
+                            class="flex h-36 w-full cursor-pointer flex-col items-center text-left"
+                            @click="$emit('open', project)"
+                        >
+                            <div
+                                v-if="project.settings.image"
+                                class="w-full flex-1 bg-cover bg-center bg-no-repeat"
+                                :style="{ backgroundImage: `url(${project.settings.image})` }"
+                            />
+
+                            <div
+                                v-else
+                                class="flex w-full flex-1 items-center justify-center bg-zinc-50 dark:bg-zinc-900"
+                            >
+                                <ImageIcon class="size-8 text-zinc-300 dark:text-zinc-600" />
+                            </div>
+                        </button>
+
+                        <div
+                            class="w-full border-t border-zinc-200 bg-white px-3 py-2 dark:border-zinc-800 dark:bg-zinc-950"
+                        >
+                            <div
+                                class="truncate text-xs font-medium text-zinc-700 dark:text-zinc-300"
+                            >
+                                {{ project.tab.name }}
+                            </div>
+                            <div class="text-[10px] text-zinc-400 dark:text-zinc-500">
+                                {{ new Date(project.tab.saved_at).toLocaleString() }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div v-else class="flex min-h-48 items-center justify-center px-5 py-8">
+                    <div class="text-center">
+                        <FolderOpenIcon
+                            class="mx-auto mb-2 size-8 text-zinc-300 dark:text-zinc-700"
+                        />
+                        <p class="text-sm font-medium text-zinc-600 dark:text-zinc-300">
+                            No saved projects yet.
+                        </p>
+                    </div>
+                </div>
+            </ScrollArea>
+        </DialogContent>
+    </Dialog>
+</template>
+
+<script setup>
+import { EditIcon, FolderOpenIcon, ImageIcon, XIcon } from 'lucide-vue-next';
+
+defineProps({
+    modelValue: { type: [Boolean, Object], default: false },
+    projects: { type: Object, required: true },
+});
+
+defineEmits(['update:modelValue', 'open', 'remove', 'rename']);
+</script>

--- a/app/components/Page.vue
+++ b/app/components/Page.vue
@@ -53,6 +53,7 @@
             class="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800"
         >
             <Preview
+                ref="previewRef"
                 :code="code"
                 :languages="languages"
                 :name="project.tab.name"
@@ -88,6 +89,8 @@ const preferences = usePreferencesStore();
 const editorRefs = ref([]);
 const editorContainerRef = ref(null);
 const previewContainerRef = ref(null);
+const previewRef = ref(null);
+const pageHasPendingChanges = ref(false);
 const splitGutterSize = 8;
 
 const { width } = useWindowSize();
@@ -232,11 +235,34 @@ const { getCodeFromEditors, getLanguagesFromEditors } = useEditorUtils();
 const code = computed(() => getCodeFromEditors(editors));
 const languages = computed(() => getLanguagesFromEditors(editors));
 
+const emitPageUpdate = debounce((data) => emit('update:page', data), 5000);
+
 watch(
     data,
-    debounce((data) => emit('update:page', data), 5000),
+    (data) => {
+        pageHasPendingChanges.value = true;
+
+        emitPageUpdate(data);
+    },
     { deep: true }
 );
+
+async function flushProjectState() {
+    emitPageUpdate.cancel();
+
+    emit('update:page', cloneDeep(data));
+
+    await nextTick();
+    await previewRef.value?.flushProjectPreview?.();
+
+    if (pageHasPendingChanges.value) {
+        emit('update:touched');
+
+        pageHasPendingChanges.value = false;
+    }
+}
+
+defineExpose({ flushProjectState });
 
 watch(
     () => editors.value.length,

--- a/app/components/Preview.vue
+++ b/app/components/Preview.vue
@@ -1,7 +1,5 @@
 <template>
     <div class="bg-pattern relative bg-white dark:bg-black">
-        <Hotkeys :shortcuts="['S']" @triggered="copyToClipboard" />
-
         <ModalCustomBackground
             v-model="showingBackgroundsModal"
             :blocks="blocks"
@@ -191,7 +189,7 @@
 
 <script setup>
 import download from 'downloadjs';
-import { debounce } from 'lodash';
+import { cloneDeep, debounce } from 'lodash';
 import { UAParser } from 'ua-parser-js';
 import * as htmlToImage from 'html-to-image';
 import {
@@ -322,6 +320,18 @@ async function generateTemplateImage() {
         console.error('Unable to generate template image.');
     }
 }
+
+async function flushProjectPreview() {
+    templateGenerationDebounce?.cancel();
+
+    await generateTokens();
+    await nextTick();
+    await generateTemplateImage();
+
+    emit('update:settings', cloneDeep(settings));
+}
+
+defineExpose({ flushProjectPreview });
 
 function saveAs(method) {
     const extension = {

--- a/app/components/Tab.vue
+++ b/app/components/Tab.vue
@@ -32,9 +32,13 @@
         </ContextMenuTrigger>
 
         <ContextMenuContent>
-            <ContextMenuItem @select="$emit('duplicate')">Duplicate</ContextMenuItem>
+            <ContextMenuItem @select="$emit('save')">Save</ContextMenuItem>
+            <ContextMenuItem @select="$emit('save-as')">Save As...</ContextMenuItem>
+            <ContextMenuSeparator />
             <ContextMenuItem @select="rename">Rename</ContextMenuItem>
-            <ContextMenuItem @select="$emit('save')">Save Project</ContextMenuItem>
+            <ContextMenuItem @select="$emit('duplicate')">Duplicate</ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem @select="close">Close Tab</ContextMenuItem>
         </ContextMenuContent>
     </ContextMenu>
 </template>
@@ -48,7 +52,7 @@ defineProps({
     modified: Boolean,
 });
 
-const emit = defineEmits(['close', 'navigate', 'duplicate', 'rename', 'save']);
+const emit = defineEmits(['close', 'navigate', 'duplicate', 'rename', 'save', 'save-as']);
 
 function close() {
     emit('close');

--- a/app/components/Tab.vue
+++ b/app/components/Tab.vue
@@ -1,6 +1,6 @@
 <template>
     <ContextMenu>
-        <ContextMenuTrigger as-child :disabled="editingName">
+        <ContextMenuTrigger as-child>
             <div
                 @click="$emit('navigate')"
                 class="animate-tab-in group relative flex h-8 max-w-[200px] min-w-[120px] cursor-pointer items-center rounded-lg transition-all select-none"
@@ -12,28 +12,14 @@
             >
                 <div class="flex size-full items-center gap-1 px-2">
                     <span
-                        v-show="!editingName"
                         :title="name || 'Untitled Project'"
-                        @dblclick.stop="startEditing"
+                        @dblclick.stop="rename"
                         class="flex-1 truncate text-center text-xs"
                     >
                         {{ name || 'Untitled Project' }}
                     </span>
 
-                    <input
-                        v-show="editingName"
-                        v-model="localName"
-                        ref="titleInput"
-                        type="text"
-                        @click.stop
-                        @blur-sm="save"
-                        @keyup.enter="save"
-                        @keyup.escape="cancelEditing"
-                        class="w-full flex-1 truncate border-0 bg-transparent p-0 text-center text-xs text-zinc-900 shadow-none focus:ring-0 focus:outline-hidden dark:text-zinc-100"
-                    />
-
                     <button
-                        v-if="!editingName"
                         type="button"
                         @click.stop="close"
                         class="shrink-0 rounded-full p-0.5 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-zinc-300 dark:hover:bg-zinc-600"
@@ -47,58 +33,29 @@
 
         <ContextMenuContent>
             <ContextMenuItem @select="$emit('duplicate')">Duplicate</ContextMenuItem>
-            <ContextMenuItem @select="toggleEditing">Rename</ContextMenuItem>
+            <ContextMenuItem @select="rename">Rename</ContextMenuItem>
+            <ContextMenuItem @select="$emit('save')">Save Project</ContextMenuItem>
         </ContextMenuContent>
     </ContextMenu>
 </template>
 
 <script setup>
-import { ref, toRefs, nextTick } from 'vue';
 import { XIcon } from 'lucide-vue-next';
 
-const props = defineProps({
+defineProps({
     name: String,
     active: Boolean,
     modified: Boolean,
 });
 
-const emit = defineEmits(['close', 'navigate', 'duplicate', 'update:name']);
+const emit = defineEmits(['close', 'navigate', 'duplicate', 'rename', 'save']);
 
-const { name } = toRefs(props);
-
-const titleInput = ref(null);
-const localName = ref(name.value);
-const editingName = ref(false);
 function close() {
-    if (props.modified && !confirm('Close this project?')) return;
-
     emit('close');
 }
 
-function save() {
-    const newName = (localName.value || '').trim().length > 0 ? localName.value : name.value;
-    emit('update:name', newName);
-    localName.value = newName;
-    editingName.value = false;
-}
-
-function toggleEditing() {
+function rename() {
     emit('navigate');
-    if (editingName.value) return save();
-    editingName.value = true;
-    nextTick(() => titleInput.value.focus());
-}
-
-function startEditing() {
-    if (!editingName.value) {
-        emit('navigate');
-        editingName.value = true;
-        nextTick(() => titleInput.value.focus());
-    }
-}
-
-function cancelEditing() {
-    localName.value = name.value;
-    editingName.value = false;
+    emit('rename');
 }
 </script>

--- a/app/components/ui/context-menu/ContextMenuSeparator.vue
+++ b/app/components/ui/context-menu/ContextMenuSeparator.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { reactiveOmit } from '@vueuse/core';
+import { ContextMenuSeparator } from 'reka-ui';
+import { cn } from '@/lib/utils';
+
+const props = defineProps({
+    asChild: { type: Boolean, required: false },
+    as: { type: null, required: false },
+    class: { type: null, required: false },
+});
+
+const delegatedProps = reactiveOmit(props, 'class');
+</script>
+
+<template>
+    <ContextMenuSeparator
+        v-bind="delegatedProps"
+        :class="cn('-mx-1 my-1 h-px bg-zinc-100 dark:bg-zinc-800', props.class)"
+    />
+</template>

--- a/app/components/ui/context-menu/index.js
+++ b/app/components/ui/context-menu/index.js
@@ -1,4 +1,5 @@
 export { default as ContextMenu } from './ContextMenu.vue';
 export { default as ContextMenuContent } from './ContextMenuContent.vue';
 export { default as ContextMenuItem } from './ContextMenuItem.vue';
+export { default as ContextMenuSeparator } from './ContextMenuSeparator.vue';
 export { default as ContextMenuTrigger } from './ContextMenuTrigger.vue';

--- a/app/composables/useProjectStores.js
+++ b/app/composables/useProjectStores.js
@@ -71,6 +71,7 @@ export default function () {
             state.page = data.page;
             state.settings = data.settings;
             state.tab.name = data.tab.name;
+            state.tab.saved_project_id = data.tab.saved_project_id;
 
             // Here we will port old editors that don't contain the newly added
             // properties from the new v1.9.0 update. v1.9.0 has also added a
@@ -141,6 +142,29 @@ export default function () {
         if (project) {
             syncProjectStateWithData(project, data);
         }
+    }
+
+    /**
+     * Add a new project from the given saved project.
+     *
+     * @param {*} savedProject
+     *
+     * @returns {Store}
+     */
+    function addProjectFromSavedProject(savedProject) {
+        const data = cloneDeep(savedProject);
+
+        data.tab.saved_project_id = savedProject.tab.id;
+
+        const project = addNewProject();
+
+        if (project) {
+            syncProjectStateWithData(project, data);
+
+            project.$patch((state) => (state.modified = false));
+        }
+
+        return project;
     }
 
     /**
@@ -238,5 +262,6 @@ export default function () {
         findProjectByTabId,
         hydrateFromStorage,
         addProjectFromTemplate,
+        addProjectFromSavedProject,
     };
 }

--- a/app/composables/useSavedProjectStore.js
+++ b/app/composables/useSavedProjectStore.js
@@ -23,14 +23,16 @@ export default defineStore('saved-projects', {
          *
          * @returns {*}
          */
-        save(project) {
-            const savedProjectId = project.tab.saved_project_id ?? uuid();
+        save(project, options = {}) {
+            const savedProjectId = options.force
+                ? uuid()
+                : (project.tab.saved_project_id ?? uuid());
             const savedProject = project.clone();
 
             savedProject.tab.id = savedProjectId;
             savedProject.tab.saved_project_id = savedProjectId;
             savedProject.tab.saved_at = new Date();
-            savedProject.tab.name = savedProject.tab.name || 'Untitled Project';
+            savedProject.tab.name = options.name || savedProject.tab.name || 'Untitled Project';
 
             const index = this.items.findIndex((item) => item.tab.id === savedProjectId);
 

--- a/app/composables/useSavedProjectStore.js
+++ b/app/composables/useSavedProjectStore.js
@@ -1,0 +1,95 @@
+import { v4 as uuid } from 'uuid';
+import { defineStore } from 'pinia';
+
+export default defineStore('saved-projects', {
+    state: () => ({
+        items: [],
+    }),
+
+    actions: {
+        /**
+         * Get all of the saved projects.
+         *
+         * @returns {Array}
+         */
+        all() {
+            return this.items;
+        },
+
+        /**
+         * Save the given project.
+         *
+         * @param {Store} project
+         *
+         * @returns {*}
+         */
+        save(project) {
+            const savedProjectId = project.tab.saved_project_id ?? uuid();
+            const savedProject = project.clone();
+
+            savedProject.tab.id = savedProjectId;
+            savedProject.tab.saved_project_id = savedProjectId;
+            savedProject.tab.saved_at = new Date();
+            savedProject.tab.name = savedProject.tab.name || 'Untitled Project';
+
+            const index = this.items.findIndex((item) => item.tab.id === savedProjectId);
+
+            if (index === -1) {
+                this.items.push(savedProject);
+            } else {
+                this.items[index] = savedProject;
+            }
+
+            project.$patch((state) => {
+                state.modified = false;
+                state.tab.saved_project_id = savedProjectId;
+                state.tab.name = savedProject.tab.name;
+            });
+
+            return savedProject;
+        },
+
+        /**
+         * Remove the given saved project.
+         *
+         * @param {*} project
+         */
+        remove(project) {
+            const index = this.items.findIndex((item) => item.tab.id === project.tab.id);
+
+            if (index !== -1) {
+                this.items.splice(index, 1);
+            }
+        },
+
+        /**
+         * Rename the given saved project.
+         *
+         * @param {*} project
+         * @param {String} name
+         */
+        rename(project, name) {
+            const savedProject = this.findById(project.tab.id);
+
+            if (savedProject) {
+                savedProject.tab.name = name;
+            }
+        },
+
+        /**
+         * Find a saved project by its ID.
+         *
+         * @param {String} id
+         *
+         * @returns {*|null}
+         */
+        findById(id) {
+            return this.items.find((item) => item.tab.id === id) || null;
+        },
+    },
+
+    persist: {
+        key: 'saved-projects',
+        storage: import.meta.client ? localStorage : undefined,
+    },
+});

--- a/app/content/changelog.md
+++ b/app/content/changelog.md
@@ -1,3 +1,24 @@
+## June 13, 2026 — Version 2.2
+
+**Added**
+
+- Ability to save projects and reopen them later from the File menu
+- Ability to save a project before closing a modified tab
+- Added desktop-style project save actions: Save, Save As..., Open..., and Close Tab
+- Added a right-click tab menu for saving, renaming, duplicating, and closing project tabs
+
+**Changed**
+
+- Project renaming now uses a dialog instead of inline tab editing
+- Command/Ctrl+S now saves the current project instead of copying the preview image
+
+**Fixed**
+
+- Fixed quick saves sometimes missing the latest project edits
+- Fixed quick saves sometimes storing an outdated project preview thumbnail
+
+---
+
 ## May 16, 2026
 
 **Added**

--- a/app/pages/download.vue
+++ b/app/pages/download.vue
@@ -38,25 +38,10 @@
                     <Button
                         as="a"
                         size="lg"
-                        class="w-full rounded-full bg-white px-8 py-6 text-lg font-semibold text-zinc-950 transition-colors hover:bg-zinc-200 sm:w-auto"
+                        class="w-full gap-1.5 rounded-full bg-white px-6 py-6 text-lg font-semibold text-zinc-950 transition-colors hover:bg-zinc-200 sm:w-auto"
                         :href="downloadUrl"
                     >
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="20"
-                            height="20"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            class="mr-2"
-                        >
-                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                            <polyline points="7 10 12 15 17 10" />
-                            <line x1="12" x2="12" y1="15" y2="3" />
-                        </svg>
+                        <DownloadIcon class="size-5" />
                         Download for {{ osName }}
                     </Button>
 
@@ -109,6 +94,7 @@
 import { ref, onMounted } from 'vue';
 import { UAParser } from 'ua-parser-js';
 import { isAppleSilicon } from 'ua-parser-js/device-detection';
+import { DownloadIcon } from 'lucide-vue-next';
 
 useSeoMeta({
     title: 'Download Showcode for Desktop',

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -74,6 +74,7 @@
                                     @duplicate="() => duplicateProject(project)"
                                     @rename="() => startRenamingProject(project)"
                                     @save="() => saveProject(project)"
+                                    @save-as="() => saveProjectAs(project)"
                                 />
                             </template>
                         </Draggable>
@@ -213,6 +214,28 @@ const saveProject = async (project = currentProject.value) => {
     return savedProject;
 };
 
+const saveProjectAs = async (project = currentProject.value) => {
+    if (!project) {
+        return toast.error('There was a problem locating the current project.');
+    }
+
+    await flushProjectState(project);
+
+    projectPendingRename.value = {
+        project,
+        type: 'tab',
+        intent: 'save-as',
+    };
+};
+
+const saveProjectAsWithName = async (project, name) => {
+    const savedProject = savedProjects.save(project, { force: true, name });
+
+    toast.success(`Saved "${savedProject.tab.name}".`);
+
+    return savedProject;
+};
+
 const saveCurrentProject = async () => {
     if (!currentProject.value) {
         return toast.error('There was a problem locating the current project.');
@@ -301,6 +324,14 @@ const renameProject = (name) => {
         return;
     }
 
+    if (pending.intent === 'save-as') {
+        projectPendingRename.value = null;
+
+        saveProjectAsWithName(pending.project, name);
+
+        return;
+    }
+
     if (pending.type === 'saved') {
         savedProjects.rename(pending.project, name);
     } else {
@@ -371,12 +402,17 @@ const fileOptions = computed(() => {
         },
         {
             name: 'save-project',
-            title: 'Save Project',
+            title: 'Save',
             click: saveCurrentProject,
         },
         {
+            name: 'save-project-as',
+            title: 'Save As...',
+            click: () => saveProjectAs(currentProject.value),
+        },
+        {
             name: 'open-saved-projects-modal',
-            title: 'Open Saved Project',
+            title: 'Open...',
             click: () => (showingSavedProjectsModal.value = true),
         },
         {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -182,7 +182,7 @@ const toolbarViewport = computed(
 const projectRenameDialog = computed(() => {
     if (projectPendingRename.value?.intent === 'save-as') {
         return {
-            title: 'Save project as',
+            title: 'Save As',
             description: 'Choose a name for this saved project copy.',
             action: 'Save',
         };

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -24,6 +24,9 @@
         />
         <ModalRenameProject
             :project="projectPendingRename?.project"
+            :title="projectRenameDialog.title"
+            :description="projectRenameDialog.description"
+            :action="projectRenameDialog.action"
             @rename="renameProject"
             @cancel="projectPendingRename = null"
         />
@@ -175,6 +178,22 @@ const activePage = ref(null);
 const toolbarViewport = computed(
     () => toolbarScrollArea.value?.$el?.querySelector?.('[data-reka-scroll-area-viewport]') ?? null
 );
+
+const projectRenameDialog = computed(() => {
+    if (projectPendingRename.value?.intent === 'save-as') {
+        return {
+            title: 'Save project as',
+            description: 'Choose a name for this saved project copy.',
+            action: 'Save',
+        };
+    }
+
+    return {
+        title: 'Rename project',
+        description: 'Update the project name shown in tabs and saved projects.',
+        action: 'Rename',
+    };
+});
 
 const newProjectFromTemplate = (template) => {
     addProjectFromTemplate(template);

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -389,16 +389,11 @@ const fileOptions = computed(() => {
     return [
         {
             name: 'preferences',
-            title: 'Preferences',
+            title: 'Preferences...',
             click: () => (showingPreferencesModal.value = true),
         },
         {
             separator: true,
-        },
-        {
-            name: 'save-as-template',
-            title: 'Save As Template',
-            click: saveAsTemplate,
         },
         {
             name: 'save-project',
@@ -411,13 +406,18 @@ const fileOptions = computed(() => {
             click: () => saveProjectAs(currentProject.value),
         },
         {
+            name: 'save-as-template',
+            title: 'Save As Template',
+            click: saveAsTemplate,
+        },
+        {
             name: 'open-saved-projects-modal',
             title: 'Open...',
             click: () => (showingSavedProjectsModal.value = true),
         },
         {
             name: 'open-templates-modal',
-            title: 'Open Saved Templates',
+            title: 'Open Saved Templates...',
             click: () => (showingTemplatesModal.value = true),
         },
         {
@@ -435,7 +435,7 @@ const fileOptions = computed(() => {
         },
         {
             name: 'import-config',
-            title: 'Import JSON Configuration',
+            title: 'Import JSON Configuration...',
             click: importNewProject,
         },
         {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -4,11 +4,29 @@
             v-if="config.isDesktop && (config.platform.darwin || config.platform.windows)"
         />
 
-        <Hotkeys v-if="config.isDesktop" :shortcuts="['T']" @triggered="() => addNewProject()" />
+        <Hotkeys :shortcuts="['S', 'T']" @triggered="handleShortcut" />
 
         <ModalHelp v-model="showingHelpModal" />
         <ModalChangelog v-model="showingChangelogModal" />
         <ModalPreferences v-model="showingPreferencesModal" />
+        <ModalSavedProjects
+            v-model="showingSavedProjectsModal"
+            :projects="savedProjects"
+            @open="openSavedProject"
+            @remove="removeSavedProject"
+            @rename="renameSavedProject"
+        />
+        <ModalCloseProject
+            :project="projectPendingClose"
+            @save="saveProjectPendingClose"
+            @discard="discardProjectPendingClose"
+            @cancel="projectPendingClose = null"
+        />
+        <ModalRenameProject
+            :project="projectPendingRename?.project"
+            @rename="renameProject"
+            @cancel="projectPendingRename = null"
+        />
 
         <ModalTemplates
             v-model="showingTemplatesModal"
@@ -51,12 +69,11 @@
                                     :modified="project.modified"
                                     :data-tab-id="project.tab.id"
                                     :active="projectIsActive(project)"
-                                    @close="() => deleteProject(project)"
+                                    @close="() => closeProject(project)"
                                     @navigate="() => setTabFromProject(project)"
                                     @duplicate="() => duplicateProject(project)"
-                                    @update:name="
-                                        project.$patch((state) => (state.tab.name = $event))
-                                    "
+                                    @rename="() => startRenamingProject(project)"
+                                    @save="() => saveProject(project)"
                                 />
                             </template>
                         </Draggable>
@@ -83,6 +100,7 @@
                     <KeepAlive>
                         <Page
                             v-if="projectIsActive(project)"
+                            ref="activePage"
                             class="size-full"
                             :project="project"
                             :key="project.tab.id"
@@ -105,6 +123,7 @@ import { usePreferredColorScheme } from '@vueuse/core';
 import useCurrentTab from '@/composables/useCurrentTab';
 import useProjectStores from '@/composables/useProjectStores';
 import useTemplateStore from '@/composables/useTemplateStore';
+import useSavedProjectStore from '@/composables/useSavedProjectStore';
 import useMetaThemeColor from '@/composables/useMetaThemeColor';
 import { colorMode, initColorMode } from '@/composables/useApplicationStore';
 import { toast } from 'vue-sonner';
@@ -117,6 +136,7 @@ initColorMode();
 const config = useRuntimeConfig().public;
 
 const templates = useTemplateStore();
+const savedProjects = useSavedProjectStore();
 
 const { update: updateMetaThemeColor } = useMetaThemeColor();
 
@@ -135,6 +155,7 @@ const {
     hydrateFromStorage,
     findProjectByTabId,
     addProjectFromTemplate,
+    addProjectFromSavedProject,
 } = useProjectStores();
 
 const loading = ref(true);
@@ -142,9 +163,13 @@ const showingHelpModal = ref(false);
 const showingChangelogModal = ref(false);
 const showingTemplatesModal = ref(false);
 const showingPreferencesModal = ref(false);
+const showingSavedProjectsModal = ref(false);
+const projectPendingClose = ref(null);
+const projectPendingRename = ref(null);
 
 const toolbarScrollArea = ref(null);
 const tabsContainer = ref(null);
+const activePage = ref(null);
 
 const toolbarViewport = computed(
     () => toolbarScrollArea.value?.$el?.querySelector?.('[data-reka-scroll-area-viewport]') ?? null
@@ -154,6 +179,141 @@ const newProjectFromTemplate = (template) => {
     addProjectFromTemplate(template);
 
     showingTemplatesModal.value = false;
+};
+
+const openSavedProject = (project) => {
+    addProjectFromSavedProject(project);
+
+    showingSavedProjectsModal.value = false;
+};
+
+async function flushProjectState(project = currentProject.value) {
+    await nextTick();
+
+    if (project && projectIsActive(project)) {
+        const page = Array.isArray(activePage.value) ? activePage.value[0] : activePage.value;
+
+        await page?.flushProjectState?.();
+
+        await nextTick();
+    }
+}
+
+const saveProject = async (project = currentProject.value) => {
+    if (!project) {
+        return toast.error('There was a problem locating the current project.');
+    }
+
+    await flushProjectState(project);
+
+    const savedProject = savedProjects.save(project);
+
+    toast.success(`Saved "${savedProject.tab.name}".`);
+
+    return savedProject;
+};
+
+const saveCurrentProject = async () => {
+    if (!currentProject.value) {
+        return toast.error('There was a problem locating the current project.');
+    }
+
+    await flushProjectState(currentProject.value);
+
+    if (!currentProject.value.tab.name) {
+        projectPendingRename.value = {
+            project: currentProject.value,
+            type: 'tab',
+            intent: 'save',
+        };
+
+        return;
+    }
+
+    return saveProject(currentProject.value);
+};
+
+const handleShortcut = ({ keyString }) => {
+    if (keyString === 'T') {
+        return addNewProject();
+    }
+
+    if (keyString === 'S') {
+        return saveCurrentProject();
+    }
+};
+
+const closeProject = async (project) => {
+    await flushProjectState(project);
+
+    if (project.modified) {
+        projectPendingClose.value = project;
+
+        return;
+    }
+
+    deleteProject(project);
+};
+
+const saveProjectPendingClose = async () => {
+    const project = projectPendingClose.value;
+
+    if (!project) {
+        return;
+    }
+
+    await saveProject(project);
+    deleteProject(project);
+
+    projectPendingClose.value = null;
+};
+
+const discardProjectPendingClose = () => {
+    const project = projectPendingClose.value;
+
+    if (!project) {
+        return;
+    }
+
+    deleteProject(project);
+
+    projectPendingClose.value = null;
+};
+
+const removeSavedProject = (project) => {
+    if (confirm('Delete this saved project?')) {
+        savedProjects.remove(project);
+    }
+};
+
+const renameSavedProject = (project) => {
+    projectPendingRename.value = { project, type: 'saved' };
+};
+
+const startRenamingProject = (project) => {
+    projectPendingRename.value = { project, type: 'tab' };
+};
+
+const renameProject = (name) => {
+    const pending = projectPendingRename.value;
+
+    if (!pending) {
+        return;
+    }
+
+    if (pending.type === 'saved') {
+        savedProjects.rename(pending.project, name);
+    } else {
+        pending.project.$patch((state) => (state.tab.name = name));
+    }
+
+    toast.success(`Project renamed to "${name}".`);
+
+    projectPendingRename.value = null;
+
+    if (pending.intent === 'save') {
+        saveProject(pending.project);
+    }
 };
 
 const removeTemplate = (template) => {
@@ -208,6 +368,16 @@ const fileOptions = computed(() => {
             name: 'save-as-template',
             title: 'Save As Template',
             click: saveAsTemplate,
+        },
+        {
+            name: 'save-project',
+            title: 'Save Project',
+            click: saveCurrentProject,
+        },
+        {
+            name: 'open-saved-projects-modal',
+            title: 'Open Saved Project',
+            click: () => (showingSavedProjectsModal.value = true),
         },
         {
             name: 'open-templates-modal',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "showcode",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "showcode",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "license": "MIT",
             "devDependencies": {
                 "@formkit/auto-animate": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "showcode",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "private": true,
     "description": "Generate beautiful images of code.",
     "repository": {

--- a/tests/components/Hotkeys.test.js
+++ b/tests/components/Hotkeys.test.js
@@ -1,0 +1,30 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, afterEach } from 'vitest';
+import Hotkeys from '~/components/Hotkeys.vue';
+
+describe('Hotkeys', () => {
+    afterEach(() => {
+        document.dispatchEvent(new KeyboardEvent('keyup'));
+    });
+
+    it('emits supported command shortcuts', async () => {
+        const wrapper = mount(Hotkeys, {
+            props: {
+                shortcuts: ['S'],
+            },
+        });
+
+        document.dispatchEvent(
+            new KeyboardEvent('keydown', {
+                keyCode: 'S'.charCodeAt(0),
+                ctrlKey: true,
+                metaKey: true,
+            })
+        );
+
+        expect(wrapper.emitted('triggered')[0][0]).toMatchObject({
+            key: 'S'.charCodeAt(0),
+            keyString: 'S',
+        });
+    });
+});

--- a/tests/components/Page.test.js
+++ b/tests/components/Page.test.js
@@ -1,0 +1,73 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import Page from '~/components/Page.vue';
+
+const EditorStub = {
+    name: 'Editor',
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: `
+        <button type="button" @click="$emit('update:modelValue', 'changed code')">
+            {{ modelValue }}
+        </button>
+    `,
+};
+
+const PreviewStub = {
+    name: 'Preview',
+    emits: ['update:settings'],
+    setup(_, { emit, expose }) {
+        expose({
+            flushProjectPreview: () => emit('update:settings', { image: 'fresh-preview' }),
+        });
+    },
+    template: '<div />',
+};
+
+function mountPage() {
+    return mount(Page, {
+        props: {
+            project: {
+                tab: { name: 'Test Project' },
+                viewport: {},
+                settings: {},
+                page: {
+                    editors: [
+                        {
+                            id: 'editor-1',
+                            added: [],
+                            removed: [],
+                            focused: [],
+                            language: 'php',
+                            tabSize: 4,
+                            value: 'original code',
+                        },
+                    ],
+                },
+            },
+        },
+        global: {
+            stubs: {
+                Editor: EditorStub,
+                Preview: PreviewStub,
+            },
+        },
+    });
+}
+
+describe('Page', () => {
+    it('flushes pending page changes immediately', async () => {
+        const wrapper = mountPage();
+
+        await wrapper.getComponent(EditorStub).trigger('click');
+
+        await wrapper.vm.flushProjectState();
+
+        const pageUpdates = wrapper.emitted('update:page');
+        const latestPage = pageUpdates[pageUpdates.length - 1][0];
+
+        expect(latestPage.editors[0].value).toBe('changed code');
+        expect(wrapper.emitted('update:touched')).toHaveLength(1);
+        expect(wrapper.emitted('update:settings')[0][0]).toEqual({ image: 'fresh-preview' });
+    });
+});

--- a/tests/components/Tab.test.js
+++ b/tests/components/Tab.test.js
@@ -1,0 +1,66 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import Tab from '~/components/Tab.vue';
+
+const ContextMenuStub = {
+    template: '<div><slot /></div>',
+};
+
+const ContextMenuTriggerStub = {
+    template: '<div><slot /></div>',
+};
+
+const ContextMenuContentStub = {
+    template: '<div><slot /></div>',
+};
+
+const ContextMenuItemStub = {
+    emits: ['select'],
+    template: '<button type="button" @click="$emit(\'select\')"><slot /></button>',
+};
+
+const ContextMenuSeparatorStub = {
+    template: '<hr />',
+};
+
+function mountTab() {
+    return mount(Tab, {
+        props: {
+            name: 'Saved Project',
+            active: true,
+            modified: false,
+        },
+        global: {
+            stubs: {
+                ContextMenu: ContextMenuStub,
+                ContextMenuTrigger: ContextMenuTriggerStub,
+                ContextMenuContent: ContextMenuContentStub,
+                ContextMenuItem: ContextMenuItemStub,
+                ContextMenuSeparator: ContextMenuSeparatorStub,
+            },
+        },
+    });
+}
+
+describe('Tab', () => {
+    it('shows common desktop save states in the context menu', async () => {
+        const wrapper = mountTab();
+
+        expect(wrapper.findAll('button').map((button) => button.text())).toEqual([
+            '',
+            'Save',
+            'Save As...',
+            'Rename',
+            'Duplicate',
+            'Close Tab',
+        ]);
+
+        await wrapper.findAll('button')[1].trigger('click');
+        await wrapper.findAll('button')[2].trigger('click');
+        await wrapper.findAll('button')[5].trigger('click');
+
+        expect(wrapper.emitted('save')).toHaveLength(1);
+        expect(wrapper.emitted('save-as')).toHaveLength(1);
+        expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+});

--- a/tests/composables/useProjectStores.test.js
+++ b/tests/composables/useProjectStores.test.js
@@ -162,4 +162,30 @@ describe('useProjectStores', () => {
         expect(duplicate.settings).toEqual(project.settings);
         expect(currentTab.value).toBe(duplicate.tab.id);
     });
+
+    it('adds a project from a saved project', () => {
+        const { projects, addProjectFromSavedProject } = useProjectStores();
+        const { currentTab } = useCurrentTab();
+
+        const savedProject = {
+            version: '1.26.1',
+            page: { editors: [{ code: 'echo "Saved";' }] },
+            settings: { themeName: 'github-dark' },
+            tab: {
+                id: 'saved-project',
+                name: 'Saved Project',
+            },
+        };
+
+        const project = addProjectFromSavedProject(savedProject);
+
+        expect(projects.value).toHaveLength(1);
+        expect(project.tab.id).not.toBe(savedProject.tab.id);
+        expect(project.tab.saved_project_id).toBe(savedProject.tab.id);
+        expect(project.tab.name).toBe('Saved Project');
+        expect(project.page).toEqual(savedProject.page);
+        expect(project.settings).toEqual(savedProject.settings);
+        expect(project.modified).toBe(false);
+        expect(currentTab.value).toBe(project.tab.id);
+    });
 });

--- a/tests/composables/useSavedProjectStore.test.js
+++ b/tests/composables/useSavedProjectStore.test.js
@@ -52,6 +52,22 @@ describe('useSavedProjectStore', () => {
         expect(savedProjects.findById(firstSave.tab.id).tab.name).toBe('Updated Name');
     });
 
+    it('forces a new saved project', () => {
+        const project = useProjectStoreFactory(`${namespace}project`)();
+
+        project.tab.name = 'Original Name';
+
+        const firstSave = savedProjects.save(project);
+        const secondSave = savedProjects.save(project, { force: true, name: 'Copied Name' });
+
+        expect(savedProjects.all()).toHaveLength(2);
+        expect(secondSave.tab.id).not.toBe(firstSave.tab.id);
+        expect(secondSave.tab.name).toBe('Copied Name');
+        expect(project.tab.saved_project_id).toBe(secondSave.tab.id);
+        expect(project.tab.name).toBe('Copied Name');
+        expect(project.modified).toBe(false);
+    });
+
     it('removes a saved project', () => {
         const project = useProjectStoreFactory(`${namespace}project`)();
         const savedProject = savedProjects.save(project);

--- a/tests/composables/useSavedProjectStore.test.js
+++ b/tests/composables/useSavedProjectStore.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import useSavedProjectStore from '~/composables/useSavedProjectStore';
+import useProjectStoreFactory from '~/composables/useProjectStoreFactory';
+import { namespace } from '~/composables/useProjectStores';
+
+describe('useSavedProjectStore', () => {
+    let savedProjects;
+
+    beforeEach(() => {
+        localStorage.clear();
+
+        savedProjects = useSavedProjectStore();
+
+        savedProjects.$reset();
+    });
+
+    it('starts with no saved projects', () => {
+        expect(savedProjects.all()).toEqual([]);
+    });
+
+    it('saves a project', () => {
+        const project = useProjectStoreFactory(`${namespace}project`)();
+
+        project.tab.name = 'My Project';
+        project.page = { editors: [{ code: 'echo "Hello";' }] };
+        project.settings = { themeName: 'github-dark' };
+        project.modified = true;
+
+        const savedProject = savedProjects.save(project);
+
+        expect(savedProjects.all()).toHaveLength(1);
+        expect(savedProject.tab.name).toBe('My Project');
+        expect(savedProject.tab.id).toBe(project.tab.saved_project_id);
+        expect(savedProject.page).toEqual(project.page);
+        expect(savedProject.settings).toEqual(project.settings);
+        expect(project.modified).toBe(false);
+    });
+
+    it('updates an existing saved project', () => {
+        const project = useProjectStoreFactory(`${namespace}project`)();
+
+        project.tab.name = 'Original Name';
+
+        const firstSave = savedProjects.save(project);
+
+        project.tab.name = 'Updated Name';
+
+        const secondSave = savedProjects.save(project);
+
+        expect(savedProjects.all()).toHaveLength(1);
+        expect(secondSave.tab.id).toBe(firstSave.tab.id);
+        expect(savedProjects.findById(firstSave.tab.id).tab.name).toBe('Updated Name');
+    });
+
+    it('removes a saved project', () => {
+        const project = useProjectStoreFactory(`${namespace}project`)();
+        const savedProject = savedProjects.save(project);
+
+        savedProjects.remove(savedProject);
+
+        expect(savedProjects.all()).toHaveLength(0);
+    });
+
+    it('renames a saved project', () => {
+        const project = useProjectStoreFactory(`${namespace}project`)();
+        const savedProject = savedProjects.save(project);
+
+        savedProjects.rename(savedProject, 'New Name');
+
+        expect(savedProjects.findById(savedProject.tab.id).tab.name).toBe('New Name');
+    });
+});


### PR DESCRIPTION
This PR adds desktop-style project saving to tabs and the File menu.

- Adds saved projects that can be reopened later
- Adds save-before-close handling for modified project tabs
- Adds tab right-click actions for Save, Save As, Rename, Duplicate, and Close Tab
- Moves project renaming into a dialog
- Rebinds Cmd/Ctrl+S to save the current project
- Flushes pending project edits and preview thumbnails before saving