### PR TITLE
Add project tab bulk close actions

### DIFF
--- a/app/components/Tab.vue
+++ b/app/components/Tab.vue
@@ -39,6 +39,21 @@
             <ContextMenuItem @select="$emit('duplicate')">Duplicate</ContextMenuItem>
             <ContextMenuSeparator />
             <ContextMenuItem @select="close">Close Tab</ContextMenuItem>
+            <ContextMenuItem :disabled="!canCloseOthers" @select="$emit('close-others')">
+                Close Other Projects
+            </ContextMenuItem>
+            <ContextMenuItem
+                :disabled="!canCloseProjectsToLeft"
+                @select="$emit('close-projects-to-left')"
+            >
+                Close Projects to the Left
+            </ContextMenuItem>
+            <ContextMenuItem
+                :disabled="!canCloseProjectsToRight"
+                @select="$emit('close-projects-to-right')"
+            >
+                Close Projects to the Right
+            </ContextMenuItem>
         </ContextMenuContent>
     </ContextMenu>
 </template>
@@ -50,9 +65,22 @@ defineProps({
     name: String,
     active: Boolean,
     modified: Boolean,
+    canCloseOthers: Boolean,
+    canCloseProjectsToLeft: Boolean,
+    canCloseProjectsToRight: Boolean,
 });
 
-const emit = defineEmits(['close', 'navigate', 'duplicate', 'rename', 'save', 'save-as']);
+const emit = defineEmits([
+    'close',
+    'navigate',
+    'duplicate',
+    'rename',
+    'save',
+    'save-as',
+    'close-others',
+    'close-projects-to-left',
+    'close-projects-to-right',
+]);
 
 function close() {
     emit('close');

--- a/app/content/changelog.md
+++ b/app/content/changelog.md
@@ -1,3 +1,11 @@
+## June 19, 2026 — Version 2.5
+
+**Added**
+
+- Added project tab menu actions for closing other projects, projects to the left, and projects to the right
+
+---
+
 ## June 14, 2026 — Version 2.4
 
 **Added**

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -20,7 +20,7 @@
             :project="projectPendingClose"
             @save="saveProjectPendingClose"
             @discard="discardProjectPendingClose"
-            @cancel="projectPendingClose = null"
+            @cancel="cancelClosingProjects"
         />
         <ModalRenameProject
             :project="projectPendingRename?.project"
@@ -72,7 +72,13 @@
                                     :modified="project.modified"
                                     :data-tab-id="project.tab.id"
                                     :active="projectIsActive(project)"
+                                    :can-close-others="projects.length > 1"
+                                    :can-close-projects-to-left="index > 0"
+                                    :can-close-projects-to-right="index < projects.length - 1"
                                     @close="() => closeProject(project)"
+                                    @close-others="() => closeOtherProjects(project)"
+                                    @close-projects-to-left="() => closeProjectsToLeft(project)"
+                                    @close-projects-to-right="() => closeProjectsToRight(project)"
                                     @navigate="() => setTabFromProject(project)"
                                     @duplicate="() => duplicateProject(project)"
                                     @rename="() => startRenamingProject(project)"
@@ -169,6 +175,7 @@ const showingTemplatesModal = ref(false);
 const showingPreferencesModal = ref(false);
 const showingSavedProjectsModal = ref(false);
 const projectPendingClose = ref(null);
+const projectsPendingClose = ref([]);
 const projectPendingRename = ref(null);
 
 const toolbarScrollArea = ref(null);
@@ -322,6 +329,59 @@ const closeProject = async (project) => {
     deleteProject(project);
 };
 
+const closeProjects = async (projectsToClose) => {
+    const uniqueProjects = projectsToClose.filter(
+        (project, index, projects) =>
+            projects.findIndex(({ tab }) => tab.id === project.tab.id) === index
+    );
+
+    for (const project of uniqueProjects) {
+        await flushProjectState(project);
+    }
+
+    const modifiedProjects = uniqueProjects.filter((project) => project.modified);
+
+    uniqueProjects
+        .filter((project) => !project.modified)
+        .forEach((project) => deleteProject(project));
+
+    projectsPendingClose.value = modifiedProjects.slice(1);
+    projectPendingClose.value = head(modifiedProjects) ?? null;
+};
+
+const closeOtherProjects = (project) => {
+    closeProjects(projects.value.filter(({ tab }) => tab.id !== project.tab.id));
+};
+
+const closeProjectsToLeft = (project) => {
+    const index = projects.value.findIndex(({ tab }) => tab.id === project.tab.id);
+
+    if (index === -1) {
+        return;
+    }
+
+    closeProjects(projects.value.slice(0, index));
+};
+
+const closeProjectsToRight = (project) => {
+    const index = projects.value.findIndex(({ tab }) => tab.id === project.tab.id);
+
+    if (index === -1) {
+        return;
+    }
+
+    closeProjects(projects.value.slice(index + 1));
+};
+
+const continueClosingProjects = () => {
+    projectPendingClose.value = projectsPendingClose.value.shift() ?? null;
+};
+
+const cancelClosingProjects = () => {
+    projectPendingClose.value = null;
+    projectsPendingClose.value = [];
+};
+
 const saveProjectPendingClose = async () => {
     const project = projectPendingClose.value;
 
@@ -332,7 +392,7 @@ const saveProjectPendingClose = async () => {
     await saveProject(project);
     deleteProject(project);
 
-    projectPendingClose.value = null;
+    continueClosingProjects();
 };
 
 const discardProjectPendingClose = () => {
@@ -344,7 +404,7 @@ const discardProjectPendingClose = () => {
 
     deleteProject(project);
 
-    projectPendingClose.value = null;
+    continueClosingProjects();
 };
 
 const removeSavedProject = (project) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "showcode",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "showcode",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "license": "MIT",
             "devDependencies": {
                 "@formkit/auto-animate": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "showcode",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "private": true,
     "description": "Generate beautiful images of code.",
     "repository": {

--- a/tests/components/Tab.test.js
+++ b/tests/components/Tab.test.js
@@ -29,6 +29,9 @@ function mountTab() {
             name: 'Saved Project',
             active: true,
             modified: false,
+            canCloseOthers: true,
+            canCloseProjectsToLeft: true,
+            canCloseProjectsToRight: true,
         },
         global: {
             stubs: {
@@ -53,14 +56,23 @@ describe('Tab', () => {
             'Rename',
             'Duplicate',
             'Close Tab',
+            'Close Other Projects',
+            'Close Projects to the Left',
+            'Close Projects to the Right',
         ]);
 
         await wrapper.findAll('button')[1].trigger('click');
         await wrapper.findAll('button')[2].trigger('click');
         await wrapper.findAll('button')[5].trigger('click');
+        await wrapper.findAll('button')[6].trigger('click');
+        await wrapper.findAll('button')[7].trigger('click');
+        await wrapper.findAll('button')[8].trigger('click');
 
         expect(wrapper.emitted('save')).toHaveLength(1);
         expect(wrapper.emitted('save-as')).toHaveLength(1);
         expect(wrapper.emitted('close')).toHaveLength(1);
+        expect(wrapper.emitted('close-others')).toHaveLength(1);
+        expect(wrapper.emitted('close-projects-to-left')).toHaveLength(1);
+        expect(wrapper.emitted('close-projects-to-right')).toHaveLength(1);
     });
 });


### PR DESCRIPTION
## What changed

Adds three right-click actions to project tabs:

- Close Other Projects
- Close Projects to the Left
- Close Projects to the Right

The tab menu disables directional close actions when there are no projects in that direction, and disables Close Other Projects when only one project is open.

## Why

Developers familiar with IDE tab management expect quick ways to close surrounding tabs without closing each project one at a time. This brings the project tab menu closer to that workflow.

## Behavior

Clean projects close immediately. Modified projects continue to use the existing save/discard/cancel confirmation flow, queued one project at a time during bulk close actions.

## Validation

Ran:

```bash
npm test -- --run tests/components/Tab.test.js tests/composables/useProjectStores.test.js
```

Result: 2 test files passed, 15 tests passed.