### PR TITLE
Add configurable preview aspect ratios

### DIFF
--- a/app/components/ControlAspectRatios.vue
+++ b/app/components/ControlAspectRatios.vue
@@ -1,5 +1,6 @@
 <template>
     <div
+        v-if="aspectRatios.length"
         class="hidden shrink-0 justify-center overflow-hidden rounded-xl border border-zinc-200 bg-white/80 shadow-lg backdrop-blur-xl md:flex dark:border-zinc-800 dark:bg-zinc-900/80"
     >
         <Button

--- a/app/components/ModalPreferences.vue
+++ b/app/components/ModalPreferences.vue
@@ -558,8 +558,11 @@ const editorThemes = computed(() => {
 });
 
 const canAddCustomAspectRatio = computed(() => {
-    return [customAspectRatioWidth.value, customAspectRatioHeight.value].every(
-        (value) => Number.isFinite(Number(value)) && Number(value) > 0
+    const ratio = [Number(customAspectRatioWidth.value), Number(customAspectRatioHeight.value)];
+
+    return (
+        ratio.every((value) => Number.isFinite(value) && value > 0) &&
+        !preferences.hasAspectRatio(ratio)
     );
 });
 
@@ -568,7 +571,7 @@ function addCustomAspectRatio() {
         return;
     }
 
-    preferences.previewAspectRatios.push([
+    preferences.addAspectRatio([
         Number(customAspectRatioWidth.value),
         Number(customAspectRatioHeight.value),
     ]);

--- a/app/components/ModalPreferences.vue
+++ b/app/components/ModalPreferences.vue
@@ -282,6 +282,63 @@
                                         </SettingsRow>
                                     </template>
                                 </SettingsSection>
+
+                                <SettingsSection title="Aspect Ratios">
+                                    <SettingsRow
+                                        label="Add Ratio"
+                                        description="Add a width and height pair"
+                                    >
+                                        <div class="flex items-center gap-2">
+                                            <Input
+                                                min="1"
+                                                type="number"
+                                                v-model="customAspectRatioWidth"
+                                                class="w-16"
+                                            />
+                                            <span class="text-xs text-zinc-400">:</span>
+                                            <Input
+                                                min="1"
+                                                type="number"
+                                                v-model="customAspectRatioHeight"
+                                                class="w-16"
+                                            />
+                                            <Button
+                                                size="icon-sm"
+                                                :disabled="!canAddCustomAspectRatio"
+                                                @click="addCustomAspectRatio"
+                                            >
+                                                <PlusIcon class="size-3.5" />
+                                            </Button>
+                                        </div>
+                                    </SettingsRow>
+
+                                    <SettingsRow
+                                        v-for="([x, y], index) in preferences.previewAspectRatios"
+                                        :key="`${x}:${y}:${index}`"
+                                        :label="`${x}:${y}`"
+                                    >
+                                        <Button
+                                            size="icon-sm"
+                                            variant="ghost"
+                                            @click="deleteAspectRatio(index)"
+                                        >
+                                            <XIcon class="size-3.5" />
+                                        </Button>
+                                    </SettingsRow>
+
+                                    <SettingsRow
+                                        label="Reset Defaults"
+                                        description="Restore 16:9, 4:3, and 1:1"
+                                    >
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            @click="preferences.resetAspectRatios()"
+                                        >
+                                            Reset
+                                        </Button>
+                                    </SettingsRow>
+                                </SettingsSection>
                             </TabsContent>
 
                             <!-- Social -->
@@ -438,9 +495,11 @@ import {
     ShareIcon,
     DownloadIcon,
     PaletteIcon,
+    PlusIcon,
     SunIcon,
     MoonIcon,
     SunriseIcon,
+    XIcon,
 } from 'lucide-vue-next';
 import useFonts from '@/composables/useFonts';
 import useSocials from '@/composables/useSocials';
@@ -458,6 +517,8 @@ const { $shiki } = useNuxtApp();
 const { options: languageOptions } = useLanguages();
 const activeTab = ref('editor');
 const isAutoColorScheme = ref(null);
+const customAspectRatioWidth = ref('');
+const customAspectRatioHeight = ref('');
 const preferences = usePreferencesStore();
 const { types: socialTypes, positions: socialPositions } = useSocials();
 
@@ -483,6 +544,30 @@ const editorThemes = computed(() => {
     });
     return orderBy(themes, 'title');
 });
+
+const canAddCustomAspectRatio = computed(() => {
+    return [customAspectRatioWidth.value, customAspectRatioHeight.value].every(
+        (value) => Number.isFinite(Number(value)) && Number(value) > 0
+    );
+});
+
+function addCustomAspectRatio() {
+    if (!canAddCustomAspectRatio.value) {
+        return;
+    }
+
+    preferences.previewAspectRatios.push([
+        Number(customAspectRatioWidth.value),
+        Number(customAspectRatioHeight.value),
+    ]);
+
+    customAspectRatioWidth.value = '';
+    customAspectRatioHeight.value = '';
+}
+
+function deleteAspectRatio(index) {
+    preferences.previewAspectRatios.splice(index, 1);
+}
 
 function setColorMode(mode) {
     isAutoColorScheme.value = mode === 'auto';

--- a/app/components/ModalPreferences.vue
+++ b/app/components/ModalPreferences.vue
@@ -313,25 +313,29 @@
                                     </SettingsRow>
 
                                     <SettingsRow label="Saved Ratios">
-                                        <div
+                                        <Draggable
                                             v-if="preferences.previewAspectRatios.length"
+                                            v-model="preferences.previewAspectRatios"
+                                            :item-key="aspectRatioKey"
+                                            tag="div"
                                             class="flex max-w-96 flex-wrap justify-end gap-1.5"
+                                            ghost-class="opacity-50"
                                         >
-                                            <span
-                                                v-for="([x, y], index) in preferences.previewAspectRatios"
-                                                :key="`${x}:${y}:${index}`"
-                                                class="inline-flex h-6 items-center gap-1 rounded-md border border-zinc-200 bg-zinc-50 pr-1 pl-2 text-xs font-medium text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
-                                            >
-                                                {{ x }}:{{ y }}
-                                                <button
-                                                    type="button"
-                                                    class="inline-flex size-4 items-center justify-center rounded-sm text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
-                                                    @click="deleteAspectRatio(index)"
+                                            <template #item="{ element: [x, y], index }">
+                                                <span
+                                                    class="inline-flex h-6 cursor-grab items-center gap-1 rounded-md border border-zinc-200 bg-zinc-50 pr-1 pl-2 text-xs font-medium text-zinc-700 active:cursor-grabbing dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
                                                 >
-                                                    <XIcon class="size-3" />
-                                                </button>
-                                            </span>
-                                        </div>
+                                                    {{ x }}:{{ y }}
+                                                    <button
+                                                        type="button"
+                                                        class="inline-flex size-4 cursor-pointer items-center justify-center rounded-sm text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
+                                                        @click="deleteAspectRatio(index)"
+                                                    >
+                                                        <XIcon class="size-3" />
+                                                    </button>
+                                                </span>
+                                            </template>
+                                        </Draggable>
 
                                         <span v-else class="text-xs text-zinc-400">
                                             No saved ratios
@@ -501,6 +505,7 @@
 <script setup>
 import { orderBy } from 'lodash';
 import { storeToRefs } from 'pinia';
+import Draggable from 'vuedraggable';
 import {
     CodeIcon,
     EyeIcon,
@@ -578,6 +583,10 @@ function addCustomAspectRatio() {
 
     customAspectRatioWidth.value = '';
     customAspectRatioHeight.value = '';
+}
+
+function aspectRatioKey([x, y]) {
+    return `${x}:${y}`;
 }
 
 function deleteAspectRatio(index) {

--- a/app/components/ModalPreferences.vue
+++ b/app/components/ModalPreferences.vue
@@ -312,18 +312,30 @@
                                         </div>
                                     </SettingsRow>
 
-                                    <SettingsRow
-                                        v-for="([x, y], index) in preferences.previewAspectRatios"
-                                        :key="`${x}:${y}:${index}`"
-                                        :label="`${x}:${y}`"
-                                    >
-                                        <Button
-                                            size="icon-sm"
-                                            variant="ghost"
-                                            @click="deleteAspectRatio(index)"
+                                    <SettingsRow label="Saved Ratios">
+                                        <div
+                                            v-if="preferences.previewAspectRatios.length"
+                                            class="flex max-w-96 flex-wrap justify-end gap-1.5"
                                         >
-                                            <XIcon class="size-3.5" />
-                                        </Button>
+                                            <span
+                                                v-for="([x, y], index) in preferences.previewAspectRatios"
+                                                :key="`${x}:${y}:${index}`"
+                                                class="inline-flex h-6 items-center gap-1 rounded-md border border-zinc-200 bg-zinc-50 pr-1 pl-2 text-xs font-medium text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
+                                            >
+                                                {{ x }}:{{ y }}
+                                                <button
+                                                    type="button"
+                                                    class="inline-flex size-4 items-center justify-center rounded-sm text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
+                                                    @click="deleteAspectRatio(index)"
+                                                >
+                                                    <XIcon class="size-3" />
+                                                </button>
+                                            </span>
+                                        </div>
+
+                                        <span v-else class="text-xs text-zinc-400">
+                                            No saved ratios
+                                        </span>
                                     </SettingsRow>
 
                                     <SettingsRow

--- a/app/components/Preview.vue
+++ b/app/components/Preview.vue
@@ -502,5 +502,5 @@ onMounted(() => {
 
 onBeforeUnmount(() => templateGenerationDebounce?.cancel());
 
-const { aspectRatio, aspectRatios, selectAspectRatio, setCustomAspectRatio } = useAspectRatios();
+const { aspectRatios } = useAspectRatios();
 </script>

--- a/app/composables/useAspectRatios.js
+++ b/app/composables/useAspectRatios.js
@@ -1,9 +1,32 @@
+import { computed } from 'vue';
+import usePreferencesStore from '@/composables/usePreferencesStore';
+
+function validAspectRatio(ratio) {
+    return (
+        Array.isArray(ratio) &&
+        ratio.length === 2 &&
+        ratio.every((value) => Number.isFinite(Number(value)) && Number(value) > 0)
+    );
+}
+
+function normalizeAspectRatio([x, y]) {
+    return [Number(x), Number(y)];
+}
+
 export default function () {
-    const aspectRatios = [
-        [16, 9],
-        [4, 3],
-        [1, 1],
-    ];
+    const preferences = usePreferencesStore();
+
+    const aspectRatios = computed(() => {
+        const ratios = preferences.previewAspectRatios
+            .filter(validAspectRatio)
+            .map(normalizeAspectRatio);
+
+        return ratios.filter((ratio, index, collection) => {
+            const [x, y] = ratio;
+
+            return collection.findIndex(([rx, ry]) => rx === x && ry === y) === index;
+        });
+    });
 
     function calculateAspectRatio([x, y], height) {
         return Math.round((height / y) * x);

--- a/app/composables/usePreferencesStore.js
+++ b/app/composables/usePreferencesStore.js
@@ -3,6 +3,12 @@ import { useLocalStorage } from '@vueuse/core';
 import themes from 'monaco-themes/themes/themelist.json';
 import { pick, defaults as applyDefaults } from 'lodash';
 
+export const defaultAspectRatios = [
+    [16, 9],
+    [4, 3],
+    [1, 1],
+];
+
 export const defaults = {
     editorTabSize: 4,
     editorFontSize: 12,
@@ -20,6 +26,7 @@ export const defaults = {
     previewCodeBlurStrength: 1,
     previewFontFamily: 'font-mono-lisa',
     previewThemeName: 'github-dark',
+    previewAspectRatios: defaultAspectRatios,
 
     previewLockToWindow: false,
     previewLockToWindowPaddingX: 0,
@@ -39,6 +46,13 @@ export const defaults = {
 export default defineStore('preferences', {
     state: () => {
         const state = useLocalStorage('preferences', defaults);
+
+        if (!state.value.previewAspectRatios && state.value.previewCustomAspectRatios) {
+            state.value.previewAspectRatios = [
+                ...defaultAspectRatios,
+                ...state.value.previewCustomAspectRatios,
+            ];
+        }
 
         // Here we are enforcing the hydration of the default
         // preference values and also removing any keys
@@ -68,6 +82,10 @@ export default defineStore('preferences', {
             if (confirm('Reset all preferences?')) {
                 this.$state = defaults;
             }
+        },
+
+        resetAspectRatios() {
+            this.previewAspectRatios = defaultAspectRatios.map((ratio) => [...ratio]);
         },
     },
 });

--- a/app/composables/usePreferencesStore.js
+++ b/app/composables/usePreferencesStore.js
@@ -43,6 +43,10 @@ export const defaults = {
     socialPosition: 'bottom-center',
 };
 
+function sameAspectRatio([leftX, leftY], [rightX, rightY]) {
+    return Number(leftX) === Number(rightX) && Number(leftY) === Number(rightY);
+}
+
 export default defineStore('preferences', {
     state: () => {
         const state = useLocalStorage('preferences', defaults);
@@ -86,6 +90,20 @@ export default defineStore('preferences', {
 
         resetAspectRatios() {
             this.previewAspectRatios = defaultAspectRatios.map((ratio) => [...ratio]);
+        },
+
+        hasAspectRatio(ratio) {
+            return this.previewAspectRatios.some((existingRatio) =>
+                sameAspectRatio(existingRatio, ratio)
+            );
+        },
+
+        addAspectRatio(ratio) {
+            if (this.hasAspectRatio(ratio)) {
+                return;
+            }
+
+            this.previewAspectRatios.push(ratio);
         },
     },
 });

--- a/app/content/changelog.md
+++ b/app/content/changelog.md
@@ -1,3 +1,16 @@
+## June 22, 2026 — Version 2.7
+
+**Added**
+
+- Added configurable aspect ratios in Preferences
+- Added the ability to add, remove, and reset preview aspect ratios
+
+**Changed**
+
+- The aspect ratio bar now reflects the configured preference list and hides when no ratios are defined
+
+---
+
 ## June 19, 2026 — Version 2.6
 
 **Added**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "showcode",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "showcode",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "license": "MIT",
             "devDependencies": {
                 "@formkit/auto-animate": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "showcode",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "private": true,
     "description": "Generate beautiful images of code.",
     "repository": {

--- a/tests/components/ControlAspectRatios.test.js
+++ b/tests/components/ControlAspectRatios.test.js
@@ -1,0 +1,31 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import ControlAspectRatios from '~/components/ControlAspectRatios.vue';
+
+describe('ControlAspectRatios', () => {
+    it('renders available aspect ratios and custom option', () => {
+        const wrapper = mount(ControlAspectRatios, {
+            props: {
+                aspectRatio: [16, 9],
+                aspectRatios: [[16, 9]],
+                lockWindowSize: false,
+            },
+        });
+
+        expect(wrapper.text()).toContain('16:9');
+        expect(wrapper.text()).toContain('Custom');
+    });
+
+    it('does not render when no aspect ratios are available', () => {
+        const wrapper = mount(ControlAspectRatios, {
+            props: {
+                aspectRatio: null,
+                aspectRatios: [],
+                lockWindowSize: false,
+            },
+        });
+
+        expect(wrapper.find('button').exists()).toBe(false);
+        expect(wrapper.text()).toBe('');
+    });
+});

--- a/tests/composables/useAspectRatios.test.js
+++ b/tests/composables/useAspectRatios.test.js
@@ -1,11 +1,85 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import useAspectRatios from '~/composables/useAspectRatios';
+import usePreferencesStore from '~/composables/usePreferencesStore';
 
 describe('useAspectRatios', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
     it('returns the default aspect ratios', () => {
         const { aspectRatios } = useAspectRatios();
 
-        expect(aspectRatios).toEqual([
+        expect(aspectRatios.value).toEqual([
+            [16, 9],
+            [4, 3],
+            [1, 1],
+        ]);
+    });
+
+    it('returns aspect ratios from preferences', () => {
+        const preferences = usePreferencesStore();
+        preferences.previewAspectRatios = [
+            [21, 9],
+            [5, 4],
+        ];
+
+        const { aspectRatios } = useAspectRatios();
+
+        expect(aspectRatios.value).toEqual([
+            [21, 9],
+            [5, 4],
+        ]);
+    });
+
+    it('can return no aspect ratios', () => {
+        const preferences = usePreferencesStore();
+        preferences.previewAspectRatios = [];
+
+        const { aspectRatios } = useAspectRatios();
+
+        expect(aspectRatios.value).toEqual([]);
+    });
+
+    it('ignores duplicate aspect ratios', () => {
+        const preferences = usePreferencesStore();
+        preferences.previewAspectRatios = [
+            [16, 9],
+            [21, 9],
+            [21, 9],
+        ];
+
+        const { aspectRatios } = useAspectRatios();
+
+        expect(aspectRatios.value).toEqual([
+            [16, 9],
+            [21, 9],
+        ]);
+    });
+
+    it('ignores invalid aspect ratios', () => {
+        const preferences = usePreferencesStore();
+        preferences.previewAspectRatios = [
+            [21, 9],
+            [0, 9],
+            [-1, 9],
+            [4],
+            ['wide', 9],
+            null,
+        ];
+
+        const { aspectRatios } = useAspectRatios();
+
+        expect(aspectRatios.value).toEqual([[21, 9]]);
+    });
+
+    it('resets aspect ratios to defaults', () => {
+        const preferences = usePreferencesStore();
+        preferences.previewAspectRatios = [[21, 9]];
+
+        preferences.resetAspectRatios();
+
+        expect(preferences.previewAspectRatios).toEqual([
             [16, 9],
             [4, 3],
             [1, 1],
@@ -32,4 +106,3 @@ describe('useAspectRatios', () => {
         expect(calculateAspectRatio([1, 1], 500)).toBe(500);
     });
 });
-

--- a/tests/composables/usePreferencesStore.test.js
+++ b/tests/composables/usePreferencesStore.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import usePreferencesStore from '~/composables/usePreferencesStore';
+
+describe('usePreferencesStore', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('adds aspect ratios', () => {
+        const preferences = usePreferencesStore();
+        preferences.previewAspectRatios = [];
+
+        preferences.addAspectRatio([21, 9]);
+
+        expect(preferences.previewAspectRatios).toEqual([[21, 9]]);
+    });
+
+    it('does not add duplicate aspect ratios', () => {
+        const preferences = usePreferencesStore();
+        preferences.previewAspectRatios = [[16, 9]];
+
+        preferences.addAspectRatio([16, 9]);
+        preferences.addAspectRatio(['16', '9']);
+
+        expect(preferences.previewAspectRatios).toEqual([[16, 9]]);
+    });
+});


### PR DESCRIPTION
## Summary

Adds a Preferences setting for managing the aspect ratio presets shown in the canvas preview controls.

Users can now:

- Add their own aspect ratios, such as `21:9` or `5:4`
- Remove any preset, including the original defaults
- Reset the ratio list back to `16:9`, `4:3`, and `1:1`

When no aspect ratios are configured, the aspect ratio bar is hidden entirely and the preview remains in freeform sizing mode.

## Testing

- `npm test -- tests/composables/useAspectRatios.test.js`
- `npm test -- tests/components/ControlAspectRatios.test.js`
- `npm test`